### PR TITLE
Update to 2.0.3

### DIFF
--- a/Commands/CommandAPI-5.12/pom.xml
+++ b/Commands/CommandAPI-5.12/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-commandapi-5-12</artifactId>
     <name>UltimateAdvancementAPI-Commands-CommandAPI-5-12</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/CommandAPI-6.4.0/pom.xml
+++ b/Commands/CommandAPI-6.4.0/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-commandapi-6-4-0</artifactId>
     <name>UltimateAdvancementAPI-Commands-CommandAPI-6-4-0</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/CommandAPI-6.5.2/pom.xml
+++ b/Commands/CommandAPI-6.5.2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-commandapi-6-5-2</artifactId>
     <name>UltimateAdvancementAPI-Commands-CommandAPI-6-5-2</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/Common/pom.xml
+++ b/Commands/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-common</artifactId>
     <name>UltimateAdvancementAPI-Commands-Common</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIManager.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIManager.java
@@ -2,9 +2,9 @@ package com.fren_gor.ultimateAdvancementAPI.commands;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.util.Versions;
+import com.google.common.base.Preconditions;
 import net.byteflux.libby.Library;
 import net.byteflux.libby.LibraryManager;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +37,7 @@ public class CommandAPIManager {
      */
     @Nullable
     public static ILoadable loadManager(@NotNull LibraryManager libbyManager) {
-        Validate.notNull(libbyManager, "LibraryManager is null.");
+        Preconditions.checkNotNull(libbyManager, "LibraryManager is null.");
         CommandAPIVersion ver = CommandAPIVersion.getVersionToLoad(Versions.getNMSVersion());
         if (ver == null) {
             // Skip code down below if nms version is invalid
@@ -112,13 +112,13 @@ public class CommandAPIManager {
         private boolean enabled = false;
 
         public CommonLoadable(@NotNull ILoadable loadable) {
-            Validate.notNull(loadable, "ILoadable is null.");
+            Preconditions.checkNotNull(loadable, "ILoadable is null.");
             this.loadable = loadable;
         }
 
         @Override
         public void onLoad(@NotNull AdvancementMain main) {
-            Validate.isTrue(AdvancementMain.isLoaded(), "AdvancementMain is not loaded.");
+            Preconditions.checkArgument(AdvancementMain.isLoaded(), "AdvancementMain is not loaded.");
             this.advancementMainOwner = main.getOwningPlugin();
             loadable.onLoad(main);
         }
@@ -128,8 +128,8 @@ public class CommandAPIManager {
             if (advancementMainOwner == null) {
                 throw new IllegalStateException("Not loaded.");
             }
-            Validate.isTrue(plugin == advancementMainOwner, "AdvancementMain owning plugin isn't the provided Plugin.");
-            Validate.isTrue(plugin.isEnabled(), "Plugin isn't enabled.");
+            Preconditions.checkArgument(plugin == advancementMainOwner, "AdvancementMain owning plugin isn't the provided Plugin.");
+            Preconditions.checkArgument(plugin.isEnabled(), "Plugin isn't enabled.");
             enabled = true;
             loadable.onEnable(plugin);
         }
@@ -142,7 +142,7 @@ public class CommandAPIManager {
             if (!enabled) {
                 throw new IllegalStateException("Not enabled.");
             }
-            Validate.isTrue(plugin == advancementMainOwner, "AdvancementMain owning plugin isn't the provided Plugin.");
+            Preconditions.checkArgument(plugin == advancementMainOwner, "AdvancementMain owning plugin isn't the provided Plugin.");
             enabled = false;
             advancementMainOwner = null;
             loadable.onDisable(plugin);

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-distribution</artifactId>
     <name>UltimateAdvancementAPI-Commands-Distribution</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
     

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-common</artifactId>
     <name>UltimateAdvancementAPI-Common</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementMain.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementMain.java
@@ -6,6 +6,7 @@ import com.fren_gor.ultimateAdvancementAPI.database.DatabaseManager;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.DuplicatedException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.InvalidVersionException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
+import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
 import com.fren_gor.ultimateAdvancementAPI.util.Versions;
 import com.google.common.base.Preconditions;
 import net.byteflux.libby.BukkitLibraryManager;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.checkSync;
 import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.runSync;
 
 /**
@@ -88,7 +90,7 @@ public final class AdvancementMain {
      * @throws IllegalStateException If it is called at an invalid moment.
      */
     public void load() throws InvalidVersionException {
-        checkPrimaryThread();
+        checkSync();
         if (!LOADED.compareAndSet(false, true)) {
             throw new IllegalStateException("UltimateAdvancementAPI is getting loaded twice.");
         }
@@ -178,7 +180,7 @@ public final class AdvancementMain {
     }
 
     private void commonEnablePreDatabase() {
-        checkPrimaryThread();
+        checkSync();
         if (INVALID_VERSION.get()) {
             throw new InvalidVersionException("Incorrect minecraft version. Couldn't enable UltimateAdvancementAPI.");
         }
@@ -231,7 +233,7 @@ public final class AdvancementMain {
      * @throws InvalidVersionException If the minecraft version in use is not supported by this API version.
      */
     public void disable() {
-        checkPrimaryThread();
+        checkSync();
         if (INVALID_VERSION.get()) {
             throw new InvalidVersionException("Incorrect minecraft version. Couldn't disable UltimateAdvancementAPI.");
         }
@@ -519,12 +521,6 @@ public final class AdvancementMain {
 
     private static boolean isMcReload(@NotNull String command) {
         return command.startsWith("/minecraft:reload") || command.startsWith("minecraft:reload");
-    }
-
-    private static void checkPrimaryThread() {
-        if (!Bukkit.isPrimaryThread()) {
-            throw new IllegalStateException("Executing thread is not main thread.");
-        }
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementMain.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementMain.java
@@ -7,8 +7,8 @@ import com.fren_gor.ultimateAdvancementAPI.exceptions.DuplicatedException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.InvalidVersionException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
 import com.fren_gor.ultimateAdvancementAPI.util.Versions;
+import com.google.common.base.Preconditions;
 import net.byteflux.libby.BukkitLibraryManager;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventPriority;
@@ -61,7 +61,7 @@ public final class AdvancementMain {
      * @param owningPlugin The plugin instantiating the API.
      */
     public AdvancementMain(@NotNull Plugin owningPlugin) {
-        Validate.notNull(owningPlugin, "Plugin is null.");
+        Preconditions.checkNotNull(owningPlugin, "Plugin is null.");
         this.owningPlugin = owningPlugin;
         this.libFolder = ".libs";
     }
@@ -74,8 +74,8 @@ public final class AdvancementMain {
      *         The folder is created into the plugin directory.
      */
     public AdvancementMain(@NotNull Plugin owningPlugin, String libFolder) {
-        Validate.notNull(owningPlugin, "Plugin is null.");
-        Validate.notNull(libFolder, "Lib folder is null.");
+        Preconditions.checkNotNull(owningPlugin, "Plugin is null.");
+        Preconditions.checkNotNull(libFolder, "Lib folder is null.");
         this.owningPlugin = owningPlugin;
         this.libFolder = libFolder;
     }
@@ -279,8 +279,8 @@ public final class AdvancementMain {
     @Contract("_, _ -> new")
     public AdvancementTab createAdvancementTab(@NotNull Plugin plugin, @NotNull String namespace) throws DuplicatedException {
         checkInitialisation();
-        Validate.notNull(plugin, "Plugin is null.");
-        Validate.notNull(namespace, "Namespace is null.");
+        Preconditions.checkNotNull(plugin, "Plugin is null.");
+        Preconditions.checkNotNull(namespace, "Namespace is null.");
         if (tabs.containsKey(namespace)) {
             throw new DuplicatedException("An AdvancementTab with '" + namespace + "' namespace already exists.");
         }
@@ -302,7 +302,7 @@ public final class AdvancementMain {
     @Nullable
     public AdvancementTab getAdvancementTab(@NotNull String namespace) {
         checkInitialisation();
-        Validate.notNull(namespace, "Namespace is null.");
+        Preconditions.checkNotNull(namespace, "Namespace is null.");
         return tabs.get(namespace);
     }
 
@@ -316,7 +316,7 @@ public final class AdvancementMain {
      */
     public boolean isAdvancementTabRegistered(@NotNull String namespace) {
         checkInitialisation();
-        Validate.notNull(namespace, "Namespace is null.");
+        Preconditions.checkNotNull(namespace, "Namespace is null.");
         return tabs.containsKey(namespace);
     }
 
@@ -332,7 +332,7 @@ public final class AdvancementMain {
     @NotNull
     public Collection<@NotNull AdvancementTab> getPluginAdvancementTabs(@NotNull Plugin plugin) {
         checkInitialisation();
-        Validate.notNull(plugin, "Plugin is null.");
+        Preconditions.checkNotNull(plugin, "Plugin is null.");
         return Collections.unmodifiableCollection(pluginMap.getOrDefault(plugin, Collections.emptyList()));
     }
 
@@ -345,7 +345,7 @@ public final class AdvancementMain {
      */
     public void unregisterAdvancementTab(@NotNull String namespace) {
         checkInitialisation();
-        Validate.notNull(namespace, "Namespace is null.");
+        Preconditions.checkNotNull(namespace, "Namespace is null.");
         AdvancementTab tab = tabs.remove(namespace);
         if (tab != null)
             tab.dispose();
@@ -360,7 +360,7 @@ public final class AdvancementMain {
      */
     public void unregisterAdvancementTabs(@NotNull Plugin plugin) {
         checkInitialisation();
-        Validate.notNull(plugin, "Plugin is null.");
+        Preconditions.checkNotNull(plugin, "Plugin is null.");
         List<AdvancementTab> tabs = pluginMap.remove(plugin);
         if (tabs != null) {
             for (AdvancementTab t : tabs)
@@ -399,8 +399,8 @@ public final class AdvancementMain {
     @Nullable
     public Advancement getAdvancement(@NotNull String namespace, @NotNull String key) {
         checkInitialisation();
-        Validate.notNull(namespace, "Namespace is null.");
-        Validate.notNull(key, "Key is null.");
+        Preconditions.checkNotNull(namespace, "Namespace is null.");
+        Preconditions.checkNotNull(key, "Key is null.");
         return getAdvancement(new AdvancementKey(namespace, key));
     }
 
@@ -415,7 +415,7 @@ public final class AdvancementMain {
     @Nullable
     public Advancement getAdvancement(@NotNull AdvancementKey namespacedKey) {
         checkInitialisation();
-        Validate.notNull(namespacedKey, "AdvancementKey is null.");
+        Preconditions.checkNotNull(namespacedKey, "AdvancementKey is null.");
         AdvancementTab tab = tabs.get(namespacedKey.getNamespace());
         if (tab == null || !tab.isActive())
             return null;
@@ -503,7 +503,7 @@ public final class AdvancementMain {
      */
     public void updatePlayer(@NotNull Player player) {
         checkInitialisation();
-        Validate.notNull(player, "Player is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
         for (AdvancementTab tab : tabs.values()) {
             if (tab.isActive() && tab.isShownTo(player)) {
                 tab.updateEveryAdvancement(player);

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementTab.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementTab.java
@@ -20,9 +20,9 @@ import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutSel
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
 import com.fren_gor.ultimateAdvancementAPI.util.LazyValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey.checkNamespace;
+import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateTeamProgression;
 
 /**
  * The {@code AdvancementTab} class represents a tab in the advancement GUI.
@@ -333,7 +334,7 @@ public final class AdvancementTab {
      */
     public void updateAdvancementsToTeam(@NotNull TeamProgression pro) {
         checkInitialisation();
-        Validate.notNull(pro, "TeamProgression is null.");
+        validateTeamProgression(pro);
 
         final int best = advancements.size() + 16;
         final Set<MinecraftKeyWrapper> keys = Sets.newHashSetWithExpectedSize(best);
@@ -385,7 +386,7 @@ public final class AdvancementTab {
      */
     public void updateEveryAdvancement(@NotNull Player player) {
         checkInitialisation();
-        Validate.notNull(player, "Player is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
 
         TeamProgression pro = databaseManager.getTeamProgression(player);
 
@@ -451,8 +452,8 @@ public final class AdvancementTab {
         }
         if (initialised)
             throw new IllegalStateException("Tab is already initialised.");
-        Validate.notNull(rootAdvancement, "RootAdvancement is null.");
-        Validate.isTrue(isOwnedByThisTab(rootAdvancement), "RootAdvancement " + rootAdvancement + " is not owned by this tab.");
+        Preconditions.checkNotNull(rootAdvancement, "RootAdvancement is null.");
+        Preconditions.checkArgument(isOwnedByThisTab(rootAdvancement), "RootAdvancement " + rootAdvancement + " is not owned by this tab.");
 
         for (BaseAdvancement a : advancements) {
             if (a == null) {
@@ -542,7 +543,7 @@ public final class AdvancementTab {
      */
     public void showTab(@NotNull Player... players) {
         checkInitialisation();
-        Validate.notNull(players, "Player[] is null.");
+        Preconditions.checkNotNull(players, "Player[] is null.");
         for (Player p : players) {
             try {
                 showTab(p);
@@ -562,7 +563,7 @@ public final class AdvancementTab {
      */
     public void showTab(@NotNull Player player) {
         checkInitialisation();
-        Validate.notNull(player, "Player is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
         if (!players.containsKey(player)) {
             players.put(player, Collections.emptySet());
             updateEveryAdvancement(player);
@@ -579,7 +580,7 @@ public final class AdvancementTab {
      */
     public void hideTab(@NotNull Player... players) {
         checkInitialisation();
-        Validate.notNull(players, "Player[] is null.");
+        Preconditions.checkNotNull(players, "Player[] is null.");
         for (Player p : players) {
             try {
                 hideTab(p);
@@ -599,7 +600,7 @@ public final class AdvancementTab {
      */
     public void hideTab(@NotNull Player player) {
         checkInitialisation();
-        Validate.notNull(player, "Player is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
         checkPlayer(player);
 
         removePlayer(player, players.remove(player));
@@ -696,7 +697,7 @@ public final class AdvancementTab {
      */
     @Contract(pure = true)
     public boolean isOwnedByThisTab(@NotNull Advancement advancement) {
-        Validate.notNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
         return advancement.getKey().getNamespace().equals(namespace);
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
@@ -15,7 +15,7 @@ import com.fren_gor.ultimateAdvancementAPI.exceptions.NotGrantedException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.UserNotLoadedException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -64,8 +64,8 @@ public final class UltimateAdvancementAPI {
      */
     @NotNull
     public static UltimateAdvancementAPI getInstance(@NotNull Plugin plugin) throws APINotInstantiatedException {
-        Validate.notNull(plugin, "Plugin is null.");
-        Validate.isTrue(plugin.isEnabled(), "Plugin is not enabled.");
+        Preconditions.checkNotNull(plugin, "Plugin is null.");
+        Preconditions.checkArgument(plugin.isEnabled(), "Plugin is not enabled.");
         if (main == null) {
             throw new APINotInstantiatedException();
         }
@@ -312,8 +312,8 @@ public final class UltimateAdvancementAPI {
      *         If no code should be called, it can be put to {@code null}.
      */
     public void updatePlayerTeam(@NotNull Player playerToMove, @NotNull Player aDestTeamPlayer, @Nullable Consumer<Result> action) {
-        Validate.notNull(playerToMove, "Player to move is null.");
-        Validate.notNull(aDestTeamPlayer, "Destination player (representing destination team) is null.");
+        Preconditions.checkNotNull(playerToMove, "Player to move is null.");
+        Preconditions.checkNotNull(aDestTeamPlayer, "Destination player (representing destination team) is null.");
         callAfterLoad(playerToMove, aDestTeamPlayer, ds -> ds.updatePlayerTeam(playerToMove, aDestTeamPlayer), action);
     }
 
@@ -336,8 +336,8 @@ public final class UltimateAdvancementAPI {
      *         If no code should be called, it can be put to {@code null}.
      */
     public void updatePlayerTeam(@NotNull UUID playerToMove, @NotNull UUID aDestTeamPlayer, @Nullable Consumer<Result> action) {
-        Validate.notNull(playerToMove, "Player to move is null.");
-        Validate.notNull(aDestTeamPlayer, "Destination player (representing destination team) is null.");
+        Preconditions.checkNotNull(playerToMove, "Player to move is null.");
+        Preconditions.checkNotNull(aDestTeamPlayer, "Destination player (representing destination team) is null.");
         callAfterLoad(playerToMove, aDestTeamPlayer, ds -> ds.updatePlayerTeam(playerToMove, aDestTeamPlayer), action);
     }
 
@@ -476,9 +476,9 @@ public final class UltimateAdvancementAPI {
      *         which provides the {@link Boolean} result.
      */
     public void isUnredeemed(@NotNull Advancement advancement, @NotNull UUID uuid, @NotNull Consumer<ObjectResult<@NotNull Boolean>> action) {
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.notNull(uuid, "UUID is null.");
-        Validate.notNull(action, "Consumer is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(action, "Consumer is null.");
         // Don't query if advancement isn't granted, it should always return false
         if (!advancement.isGranted(uuid)) {
             action.accept(new ObjectResult<>(false));
@@ -588,8 +588,8 @@ public final class UltimateAdvancementAPI {
      * @throws NotGrantedException If the advancement is not granted for the specified player.
      */
     public void setUnredeemed(@NotNull Advancement advancement, @NotNull UUID uuid, boolean giveRewards, @Nullable Consumer<Result> action) throws NotGrantedException {
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         // Don't call update if advancement isn't granted, it may throw a foreign key exception
         if (!advancement.isGranted(uuid)) {
             throw new NotGrantedException();
@@ -639,8 +639,8 @@ public final class UltimateAdvancementAPI {
      *         If no code should be called, it can be put to {@code null}.
      */
     public void unsetUnredeemed(@NotNull Advancement advancement, @NotNull UUID uuid, @Nullable Consumer<Result> action) {
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         callAfterLoad(uuid, ds -> ds.unsetUnredeemed(advancement.getKey(), uuid), action);
     }
 
@@ -853,7 +853,7 @@ public final class UltimateAdvancementAPI {
      *         which provides the in-database stored name of the player.
      */
     public void getStoredPlayerName(@NotNull UUID uuid, @NotNull Consumer<ObjectResult<@Nullable String>> action) {
-        Validate.notNull(action, "Consumer is null.");
+        Preconditions.checkNotNull(action, "Consumer is null.");
         getMain().getDatabaseManager().getStoredPlayerName(uuid).thenAccept(s -> runSync(plugin, () -> action.accept(s)));
     }
 
@@ -862,7 +862,7 @@ public final class UltimateAdvancementAPI {
     }
 
     private <T extends Result> void callAfterLoad(@NotNull UUID uuid, @NotNull Function<DatabaseManager, CompletableFuture<T>> internalAction, @Nullable Consumer<T> action) {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         final DatabaseManager ds = getMain().getDatabaseManager();
         ds.loadOfflinePlayer(uuid, CacheFreeingOption.MANUAL(plugin)).thenAccept(t1 -> {
             if (t1.isExceptionOccurred()) {
@@ -942,7 +942,6 @@ public final class UltimateAdvancementAPI {
                 });
             }
         });
-
     }
 
     private <T extends Result> void callSyncIfNotNull(@NotNull CompletableFuture<T> completableFuture, @Nullable Consumer<T> action) {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/FakeAdvancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/FakeAdvancement.java
@@ -6,8 +6,8 @@ import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
 import com.fren_gor.ultimateAdvancementAPI.util.AfterHandle;
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.chat.BaseComponent;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -187,7 +187,7 @@ public final class FakeAdvancement extends BaseAdvancement {
         @Override
         @NotNull
         public AdvancementDisplayWrapper getNMSWrapper(@NotNull Advancement advancement) {
-            Validate.notNull(advancement, "Advancement is null.");
+            Preconditions.checkNotNull(advancement, "Advancement is null.");
             try {
                 return AdvancementDisplayWrapper.craft(icon, title, compactDescription, frame.getNMSWrapper(), x, y, false, false, true);
             } catch (ReflectiveOperationException e) {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -3,19 +3,17 @@ package com.fren_gor.ultimateAdvancementAPI.advancement.display;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.RootAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -204,18 +202,19 @@ public class AdvancementDisplay {
      * @param description The description of the advancement.
      */
     public AdvancementDisplay(@NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull ChatColor defaultColor, @NotNull List<String> description) {
-        Validate.notNull(icon, "Icon is null.");
-        Validate.notNull(title, "Title is null.");
-        Validate.notNull(frame, "Frame is null.");
-        Validate.notNull(defaultColor, "Default color is null.");
-        Validate.notNull(description, "Description is null.");
-        Validate.noNullElements(description, "An element of the description is null.");
-        Validate.isTrue(x >= 0, "x is not null or positive.");
-        Validate.isTrue(y >= 0, "y is not null or positive.");
+        Preconditions.checkNotNull(icon, "Icon is null.");
+        Preconditions.checkNotNull(title, "Title is null.");
+        Preconditions.checkNotNull(frame, "Frame is null.");
+        Preconditions.checkNotNull(defaultColor, "Default color is null.");
+        Preconditions.checkNotNull(description, "Description is null.");
+        for (String line : description)
+            Preconditions.checkNotNull(line, "A line of the description is null.");
+        Preconditions.checkArgument(x >= 0, "x is not null or positive.");
+        Preconditions.checkArgument(y >= 0, "y is not null or positive.");
 
         this.icon = icon.clone();
         this.title = title;
-        this.description = Collections.unmodifiableList(new ArrayList<>(description));
+        this.description = List.copyOf(description);
 
         // Remove trailing spaces and color codes
         String titleTrimmed = title.trim();
@@ -227,7 +226,7 @@ public class AdvancementDisplay {
 
         this.chatTitle[0] = new TextComponent(defaultColor + rawTitle);
         // Old code, bugged for unknown reasons (found out that BaseComponent[] must have length 1 or it bugs in HoverEvents)
-        //this.chatDescription = AdvancementUtils.fromStringList(title, this.description);
+        // this.chatDescription = AdvancementUtils.fromStringList(title, this.description);
 
         if (this.description.isEmpty()) {
             this.compactDescription = "";
@@ -307,7 +306,7 @@ public class AdvancementDisplay {
      */
     @NotNull
     public AdvancementDisplayWrapper getNMSWrapper(@NotNull Advancement advancement) {
-        Validate.notNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
         AdvancementDisplayWrapper wrapper;
         try {
             if (advancement instanceof RootAdvancement root) {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -1,9 +1,9 @@
 package com.fren_gor.ultimateAdvancementAPI.advancement.display;
 
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -150,7 +150,7 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      */
     public FancyAdvancementDisplay(@NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull ChatColor defaultTitleColor, @NotNull ChatColor defaultDescriptionColor, @NotNull List<String> description) {
         super(icon, title, frame, showToast, announceChat, x, y, defaultDescriptionColor, description);
-        Validate.notNull(defaultTitleColor, "Default title color is null.");
+        Preconditions.checkNotNull(defaultTitleColor, "Default title color is null.");
 
         this.chatTitle[0] = new TextComponent(defaultTitleColor + rawTitle);
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/multiParents/AbstractMultiParentsAdvancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/multiParents/AbstractMultiParentsAdvancement.java
@@ -3,7 +3,7 @@ package com.fren_gor.ultimateAdvancementAPI.advancement.multiParents;
 import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementDisplay;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
@@ -178,10 +178,10 @@ public abstract class AbstractMultiParentsAdvancement extends BaseAdvancement {
      */
     @NotNull
     public static <E extends BaseAdvancement> E validateAndGetFirst(@NotNull Set<E> advancements) {
-        Validate.notNull(advancements, "Parent advancements are null.");
-        Validate.isTrue(advancements.size() > 0, "There must be at least 1 parent.");
+        Preconditions.checkNotNull(advancements, "Parent advancements are null.");
+        Preconditions.checkArgument(advancements.size() > 0, "There must be at least 1 parent.");
         E e = advancements.iterator().next();
-        Validate.notNull(e, "A parent advancement is null.");
+        Preconditions.checkNotNull(e, "A parent advancement is null.");
         return e;
     }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/multiParents/MultiParentsAdvancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/multiParents/MultiParentsAdvancement.java
@@ -8,9 +8,9 @@ import com.fren_gor.ultimateAdvancementAPI.exceptions.InvalidAdvancementExceptio
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementWrapper;
 import com.fren_gor.ultimateAdvancementAPI.util.LazyValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang.Validate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+
+import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateTeamProgression;
 
 /**
  * An implementation of {@link AbstractMultiParentsAdvancement}.
@@ -132,7 +134,7 @@ public class MultiParentsAdvancement extends AbstractMultiParentsAdvancement {
      */
     @Override
     public boolean isEveryParentGranted(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression cannot be null.");
+        Preconditions.checkNotNull(pro, "TeamProgression cannot be null.");
 
         for (BaseAdvancement advancement : parents.keySet()) {
             if (!advancement.isGranted(pro)) {
@@ -147,7 +149,7 @@ public class MultiParentsAdvancement extends AbstractMultiParentsAdvancement {
      */
     @Override
     public boolean isAnyParentGranted(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression cannot be null.");
+        Preconditions.checkNotNull(pro, "TeamProgression cannot be null.");
 
         for (BaseAdvancement advancement : parents.keySet()) {
             if (advancement.isGranted(pro)) {
@@ -162,7 +164,7 @@ public class MultiParentsAdvancement extends AbstractMultiParentsAdvancement {
      */
     @Override
     public boolean isEveryGrandparentGranted(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression cannot be null.");
+        Preconditions.checkNotNull(pro, "TeamProgression cannot be null.");
 
         for (BaseAdvancement advancement : parents.keySet()) {
             if (!advancement.isGranted(pro)) { // If it is granted then continue to check the other parents
@@ -182,7 +184,7 @@ public class MultiParentsAdvancement extends AbstractMultiParentsAdvancement {
      */
     @Override
     public boolean isAnyGrandparentGranted(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression cannot be null.");
+        validateTeamProgression(pro);
 
         for (BaseAdvancement advancement : parents.keySet()) {
             if (advancement.isGranted(pro)) {
@@ -199,7 +201,7 @@ public class MultiParentsAdvancement extends AbstractMultiParentsAdvancement {
 
     // Not currently used
     /*public boolean isAnyParentStarted(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression cannot be null.");
+        Preconditions.checkNotNull(pro, "TeamProgression cannot be null.");
 
         for (BaseAdvancement advancement : parents.keySet()) {
             if (advancement.getProgression(pro) > 0) {
@@ -210,7 +212,7 @@ public class MultiParentsAdvancement extends AbstractMultiParentsAdvancement {
     }
 
     public boolean isAnyGrandparentStarted(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression cannot be null.");
+        Preconditions.checkNotNull(pro, "TeamProgression cannot be null.");
 
         for (BaseAdvancement advancement : parents.keySet()) {
             if (advancement.getProgression(pro) > 0 || isParentStarted(pro, advancement)) {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/MultiTasksAdvancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/MultiTasksAdvancement.java
@@ -7,8 +7,8 @@ import com.fren_gor.ultimateAdvancementAPI.events.team.TeamUnloadEvent;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.ArbitraryMultiTaskProgressionUpdateException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.InvalidAdvancementException;
 import com.fren_gor.ultimateAdvancementAPI.util.AfterHandle;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang.Validate;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateProgressionValueStrict;
+import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateTeamProgression;
 
 /**
  * An implementation of {@link AbstractMultiTasksAdvancement}. {@link TaskAdvancement}s have to be registered
@@ -87,11 +88,11 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
         if (initialised) {
             throw new IllegalStateException("MultiTaskAdvancement is already initialised.");
         }
-        Validate.notNull(tasks, "Set<TaskAdvancement> is null.");
+        Preconditions.checkNotNull(tasks, "Set<TaskAdvancement> is null.");
         int progression = 0;
         for (TaskAdvancement t : tasks) {
             if (t == null) {
-                throw new IllegalArgumentException("A TaskAdvancement is null.");
+                throw new NullPointerException("A TaskAdvancement is null.");
             }
             if (t.getMultiTasksAdvancement() != this) {
                 throw new IllegalArgumentException("TaskAdvancement's AbstractMultiTasksAdvancement (" + t.getMultiTasksAdvancement().getKey() + ") doesn't match with this MultiTasksAdvancement (" + key + ").");
@@ -132,7 +133,7 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
     @Range(from = 0, to = Integer.MAX_VALUE)
     public int getProgression(@NotNull TeamProgression progression) {
         checkInitialisation();
-        Validate.notNull(progression, "TeamProgression is null.");
+        validateTeamProgression(progression);
         Integer progr = progressionsCache.get(progression.getTeamId());
         if (progr == null) {
             int c = 0;
@@ -154,7 +155,7 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
     @Override
     public boolean isGranted(@NotNull TeamProgression pro) {
         checkInitialisation();
-        Validate.notNull(pro, "TeamProgression is null.");
+        validateTeamProgression(pro);
         return getProgression(pro) >= maxProgression;
     }
 
@@ -176,7 +177,7 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
     @Override
     protected void setProgression(@NotNull TeamProgression progression, @Nullable Player player, @Range(from = 0, to = Integer.MAX_VALUE) int newProgression, boolean giveRewards) throws ArbitraryMultiTaskProgressionUpdateException {
         checkInitialisation();
-        Validate.notNull(progression, "TeamProgression is null.");
+        validateTeamProgression(progression);
         validateProgressionValueStrict(newProgression, maxProgression);
 
         int current = getProgression(progression);
@@ -239,7 +240,7 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
     protected void reloadTasks(@NotNull TeamProgression progression, @Nullable Player player, boolean giveRewards) {
         checkInitialisation();
         if (doReloads) { // Skip reloads when update comes from ourselves
-            Validate.notNull(progression, "TeamProgression is null.");
+            validateTeamProgression(progression);
 
             int current = getProgression(progression);
             resetProgressionCache(progression);
@@ -263,7 +264,7 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
      * @param pro The team to remove from the cache.
      */
     public void resetProgressionCache(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression is null.");
+        validateTeamProgression(pro);
         progressionsCache.remove(pro.getTeamId());
     }
 
@@ -274,7 +275,7 @@ public class MultiTasksAdvancement extends AbstractMultiTasksAdvancement {
      * @param progression The new progression to store in cache.
      */
     protected void updateProgressionCache(@NotNull TeamProgression pro, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(pro, "TeamProgression is null.");
+        validateTeamProgression(pro);
         validateProgressionValueStrict(progression, maxProgression);
         progressionsCache.put(pro.getTeamId(), progression);
     }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/TaskAdvancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/TaskAdvancement.java
@@ -8,8 +8,8 @@ import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
 import com.fren_gor.ultimateAdvancementAPI.events.advancement.AdvancementProgressionUpdateEvent;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.InvalidAdvancementException;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.chat.BaseComponent;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateProgressionValueStrict;
+import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateTeamProgression;
 
 /**
  * The {@code TaskAdvancement} class represents a task. It can be used by any {@link AbstractMultiTasksAdvancement} subclass
@@ -96,7 +97,7 @@ public class TaskAdvancement extends BaseAdvancement {
      */
     @Override
     protected void setProgression(@NotNull TeamProgression pro, @Nullable Player player, @Range(from = 0, to = Integer.MAX_VALUE) int progression, boolean giveRewards) {
-        Validate.notNull(pro, "TeamProgression is null.");
+        validateTeamProgression(pro);
         validateProgressionValueStrict(progression, maxProgression);
 
         final DatabaseManager ds = advancementTab.getDatabaseManager();
@@ -154,7 +155,7 @@ public class TaskAdvancement extends BaseAdvancement {
      */
     @Override
     public void onGrant(@NotNull Player player, boolean giveRewards) {
-        Validate.notNull(player, "Player is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
 
         if (giveRewards)
             giveReward(player);

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/CacheFreeingOption.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/CacheFreeingOption.java
@@ -1,6 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI.database;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
@@ -62,8 +62,8 @@ public final class CacheFreeingOption {
      * @return A {@code CacheFreeingOption} instance with caching strategy <a href="./CacheFreeingOption.Option.html#AUTOMATIC"><code>CacheFreeingOption.Option#AUTOMATIC</code></a>.
      */
     public static CacheFreeingOption AUTOMATIC(@NotNull Plugin requester, @Range(from = 0, to = Long.MAX_VALUE) long ticks) {
-        Validate.notNull(requester, "Plugin is null.");
-        Validate.isTrue(requester.isEnabled(), "Plugin isn't enabled.");
+        Preconditions.checkNotNull(requester, "Plugin is null.");
+        Preconditions.checkArgument(requester.isEnabled(), "Plugin isn't enabled.");
         return new CacheFreeingOption(Option.AUTOMATIC, ticks, requester);
     }
 
@@ -74,8 +74,8 @@ public final class CacheFreeingOption {
      * @return A {@code CacheFreeingOption} instance with caching strategy <a href="./CacheFreeingOption.Option.html#MANUAL"><code>CacheFreeingOption.Option#MANUAL</code></a>.
      */
     public static CacheFreeingOption MANUAL(@NotNull Plugin requester) {
-        Validate.notNull(requester, "Plugin is null.");
-        Validate.isTrue(requester.isEnabled(), "Plugin isn't enabled.");
+        Preconditions.checkNotNull(requester, "Plugin is null.");
+        Preconditions.checkArgument(requester.isEnabled(), "Plugin isn't enabled.");
         return new CacheFreeingOption(Option.MANUAL, requester);
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
@@ -18,7 +18,7 @@ import com.fren_gor.ultimateAdvancementAPI.events.team.TeamUpdateEvent.Action;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.UserNotLoadedException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -48,6 +48,7 @@ import java.util.function.Consumer;
 
 import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.runSync;
 import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.uuidFromPlayer;
+import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validateTeamProgression;
 
 /**
  * The database manager. It handles the connection to the database and caches the requested values to improve performances.
@@ -89,7 +90,7 @@ public final class DatabaseManager {
      * @throws Exception If anything goes wrong.
      */
     public DatabaseManager(@NotNull AdvancementMain main) throws Exception {
-        Validate.notNull(main, "AdvancementMain is null.");
+        Preconditions.checkNotNull(main, "AdvancementMain is null.");
         this.main = main;
         this.eventManager = main.getEventManager();
 
@@ -105,8 +106,8 @@ public final class DatabaseManager {
      * @throws Exception If anything goes wrong.
      */
     public DatabaseManager(@NotNull AdvancementMain main, @NotNull File dbFile) throws Exception {
-        Validate.notNull(main, "AdvancementMain is null.");
-        Validate.notNull(dbFile, "Database file is null.");
+        Preconditions.checkNotNull(main, "AdvancementMain is null.");
+        Preconditions.checkNotNull(dbFile, "Database file is null.");
         this.main = main;
         this.eventManager = main.getEventManager();
 
@@ -128,7 +129,7 @@ public final class DatabaseManager {
      * @throws Exception If anything goes wrong.
      */
     public DatabaseManager(@NotNull AdvancementMain main, @NotNull String username, @NotNull String password, @NotNull String databaseName, @NotNull String host, @Range(from = 1, to = Integer.MAX_VALUE) int port, @Range(from = 1, to = Integer.MAX_VALUE) int poolSize, @Range(from = 250, to = Long.MAX_VALUE) long connectionTimeout) throws Exception {
-        Validate.notNull(main, "AdvancementMain is null.");
+        Preconditions.checkNotNull(main, "AdvancementMain is null.");
         this.main = main;
         this.eventManager = main.getEventManager();
 
@@ -339,7 +340,7 @@ public final class DatabaseManager {
      */
     @NotNull
     public CompletableFuture<Result> updatePlayerName(@NotNull Player player) {
-        Validate.notNull(player, "Player cannot be null.");
+        Preconditions.checkNotNull(player, "Player cannot be null.");
         return CompletableFuture.supplyAsync(() -> {
             try {
                 database.updatePlayerName(player.getUniqueId(), player.getName());
@@ -397,7 +398,7 @@ public final class DatabaseManager {
 
     @NotNull
     private CompletableFuture<Result> updatePlayerTeam(@NotNull UUID playerToMove, @Nullable Player ptm, @NotNull TeamProgression otherTeamProgression) throws UserNotLoadedException {
-        Validate.notNull(playerToMove, "Player to move is null.");
+        Preconditions.checkNotNull(playerToMove, "Player to move is null.");
         validateTeamProgression(otherTeamProgression);
 
         synchronized (DatabaseManager.this) {
@@ -482,7 +483,7 @@ public final class DatabaseManager {
     }
 
     private CompletableFuture<ObjectResult<@NotNull TeamProgression>> movePlayerInNewTeam(@NotNull UUID uuid, @Nullable Player ptr) throws UserNotLoadedException {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         synchronized (DatabaseManager.this) {
             if (!progressionCache.containsKey(uuid)) {
                 throw new UserNotLoadedException(uuid);
@@ -552,7 +553,7 @@ public final class DatabaseManager {
      * @see UltimateAdvancementAPI#unregisterOfflinePlayer(UUID)
      */
     public CompletableFuture<Result> unregisterOfflinePlayer(@NotNull UUID uuid) throws IllegalStateException {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         AdvancementUtils.checkSync();
         if (Bukkit.getPlayer(uuid) != null)
             throw new IllegalStateException("Player is online.");
@@ -652,9 +653,9 @@ public final class DatabaseManager {
      */
     @NotNull
     public Entry<Integer, CompletableFuture<Result>> updateProgressionWithCompletable(@NotNull AdvancementKey key, @NotNull TeamProgression progression, @Range(from = 0, to = Integer.MAX_VALUE) int newProgression) {
-        Validate.notNull(key, "Key is null.");
+        Preconditions.checkNotNull(key, "Key is null.");
         validateTeamProgression(progression);
-        Validate.isTrue(progression.getSize() > 0, "TeamProgression doesn't contain any player.");
+        Preconditions.checkArgument(progression.getSize() > 0, "TeamProgression doesn't contain any player.");
         AdvancementUtils.checkSync();
 
         int old = progression.updateProgression(key, newProgression);
@@ -705,7 +706,7 @@ public final class DatabaseManager {
      */
     @NotNull
     public synchronized TeamProgression getTeamProgression(@NotNull UUID uuid) throws UserNotLoadedException {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         TeamProgression pro = progressionCache.get(uuid);
         AdvancementUtils.checkTeamProgressionNotNull(pro, uuid);
         return pro;
@@ -789,9 +790,9 @@ public final class DatabaseManager {
     @Contract(pure = true)
     @Range(from = 0, to = MAX_SIMULTANEOUS_LOADING_REQUESTS)
     public synchronized int getLoadingRequestsAmount(@NotNull Plugin plugin, @NotNull UUID uuid, @NotNull CacheFreeingOption.Option type) {
-        Validate.notNull(plugin, "Plugin is null.");
-        Validate.notNull(uuid, "UUID is null.");
-        Validate.notNull(type, "CacheFreeingOption.Option is null.");
+        Preconditions.checkNotNull(plugin, "Plugin is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(type, "CacheFreeingOption.Option is null.");
         TempUserMetadata t = tempLoaded.get(uuid);
         if (t == null) {
             return 0;
@@ -828,7 +829,7 @@ public final class DatabaseManager {
      */
     @NotNull
     public CompletableFuture<ObjectResult<@NotNull Boolean>> isUnredeemed(@NotNull AdvancementKey key, @NotNull TeamProgression pro) {
-        Validate.notNull(key, "AdvancementKey is null.");
+        Preconditions.checkNotNull(key, "AdvancementKey is null.");
         validateTeamProgression(pro);
         return CompletableFuture.supplyAsync(() -> {
             try {
@@ -869,7 +870,7 @@ public final class DatabaseManager {
      */
     @NotNull
     public CompletableFuture<Result> setUnredeemed(@NotNull AdvancementKey key, boolean giveRewards, @NotNull TeamProgression pro) {
-        Validate.notNull(key, "AdvancementKey is null.");
+        Preconditions.checkNotNull(key, "AdvancementKey is null.");
         validateTeamProgression(pro);
         return CompletableFuture.supplyAsync(() -> {
             try {
@@ -908,7 +909,7 @@ public final class DatabaseManager {
      */
     @NotNull
     public CompletableFuture<Result> unsetUnredeemed(@NotNull AdvancementKey key, @NotNull TeamProgression pro) {
-        Validate.notNull(key, "AdvancementKey is null.");
+        Preconditions.checkNotNull(key, "AdvancementKey is null.");
         validateTeamProgression(pro);
         return CompletableFuture.supplyAsync(() -> {
             try {
@@ -933,7 +934,7 @@ public final class DatabaseManager {
      */
     @NotNull
     public CompletableFuture<ObjectResult<@NotNull String>> getStoredPlayerName(@NotNull UUID uuid) {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         return CompletableFuture.supplyAsync(() -> {
             try {
                 return new ObjectResult<>(database.getPlayerName(uuid));
@@ -963,8 +964,8 @@ public final class DatabaseManager {
      */
     @NotNull
     public synchronized CompletableFuture<ObjectResult<@NotNull TeamProgression>> loadOfflinePlayer(@NotNull UUID uuid, @NotNull CacheFreeingOption option) {
-        Validate.notNull(uuid, "UUID is null.");
-        Validate.notNull(option, "CacheFreeingOption is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(option, "CacheFreeingOption is null.");
         TeamProgression pro = progressionCache.get(uuid);
         if (pro != null) {
             handleCacheFreeingOption(uuid, null, option); // Handle requests
@@ -1052,8 +1053,8 @@ public final class DatabaseManager {
     }
 
     private synchronized void internalUnloadOfflinePlayer(@NotNull UUID uuid, @NotNull Plugin requester, boolean auto) {
-        Validate.notNull(uuid, "UUID is null.");
-        Validate.notNull(requester, "Plugin is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(requester, "Plugin is null.");
         TempUserMetadata meta = tempLoaded.get(uuid);
         if (meta != null) {
             meta.removeRequest(requester, auto);
@@ -1068,11 +1069,6 @@ public final class DatabaseManager {
                 }
             }
         }
-    }
-
-    private static void validateTeamProgression(@NotNull TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression is null.");
-        Validate.isTrue(pro.isValid(), "TeamProgression is not valid (this means it is not present in cache).");
     }
 
     private static final class TempUserMetadata {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/Result.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/Result.java
@@ -2,7 +2,7 @@ package com.fren_gor.ultimateAdvancementAPI.database;
 
 import com.fren_gor.ultimateAdvancementAPI.exceptions.IllegalOperationException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.UnhandledException;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -47,7 +47,7 @@ public class Result {
      * @throws IllegalArgumentException If {@code occurredException} is {@code null}.
      */
     public Result(@NotNull Exception occurredException) {
-        Validate.notNull(occurredException, "Exception is null.");
+        Preconditions.checkNotNull(occurredException, "Exception is null.");
         this.occurredException = occurredException;
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/TeamProgression.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/TeamProgression.java
@@ -3,9 +3,9 @@ package com.fren_gor.ultimateAdvancementAPI.database;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.IllegalOperationException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -50,7 +50,7 @@ public final class TeamProgression {
      */
     public TeamProgression(int teamId, @NotNull UUID member) {
         validateCaller(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass());
-        Validate.notNull(member, "Member is null.");
+        Preconditions.checkNotNull(member, "Member is null.");
         this.advancements = new ConcurrentHashMap<>();
         this.teamId = teamId;
         players = new HashSet<>();
@@ -70,8 +70,8 @@ public final class TeamProgression {
      */
     public TeamProgression(@NotNull Map<AdvancementKey, Integer> advancements, int teamId, @NotNull Collection<UUID> members) {
         validateCaller(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass());
-        Validate.notNull(advancements, "Advancements is null.");
-        Validate.notNull(members, "Members is null.");
+        Preconditions.checkNotNull(advancements, "Advancements is null.");
+        Preconditions.checkNotNull(members, "Members is null.");
         this.advancements = new ConcurrentHashMap<>(advancements);
         this.teamId = teamId;
         players = Sets.newHashSetWithExpectedSize(members.size() + 4);
@@ -92,7 +92,7 @@ public final class TeamProgression {
      */
     @Range(from = 0, to = Integer.MAX_VALUE)
     public int getProgression(@NotNull Advancement advancement) {
-        Validate.notNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
         Integer progression = advancements.get(advancement.getKey());
 
         if (progression != null) {
@@ -160,7 +160,7 @@ public final class TeamProgression {
      * @param action The {@link Consumer} to run for each member.
      */
     public void forEachMember(@NotNull Consumer<UUID> action) {
-        Validate.notNull(action, "Consumer is null.");
+        Preconditions.checkNotNull(action, "Consumer is null.");
         synchronized (players) {
             for (UUID u : players) {
                 action.accept(u);
@@ -176,7 +176,7 @@ public final class TeamProgression {
      * @return Whether the {@link Predicate} returns {@code true} for every member, or {@code true} if the team is empty.
      */
     public boolean everyMemberMatch(@NotNull Predicate<UUID> action) {
-        Validate.notNull(action, "Predicate is null.");
+        Preconditions.checkNotNull(action, "Predicate is null.");
         synchronized (players) {
             for (UUID u : players) {
                 if (!action.test(u)) {
@@ -195,7 +195,7 @@ public final class TeamProgression {
      * @return Whether the {@link Predicate} returns {@code true} for at least one member, or {@code false} if the team is empty.
      */
     public boolean anyMemberMatch(@NotNull Predicate<UUID> action) {
-        Validate.notNull(action, "Predicate is null.");
+        Preconditions.checkNotNull(action, "Predicate is null.");
         synchronized (players) {
             for (UUID u : players) {
                 if (action.test(u)) {
@@ -214,7 +214,7 @@ public final class TeamProgression {
      * @return Whether the {@link Predicate} returns {@code false} for every member, or {@code true} if the team is empty.
      */
     public boolean noMemberMatch(@NotNull Predicate<UUID> action) {
-        Validate.notNull(action, "Predicate is null.");
+        Preconditions.checkNotNull(action, "Predicate is null.");
         synchronized (players) {
             for (UUID u : players) {
                 if (action.test(u)) {
@@ -266,7 +266,7 @@ public final class TeamProgression {
      * @param uuid The {@link UUID} of the player to be added.
      */
     void addMember(@NotNull UUID uuid) {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         synchronized (players) {
             players.add(uuid);
         }
@@ -293,7 +293,7 @@ public final class TeamProgression {
      */
     @Nullable
     public Player getAnOnlineMember(@NotNull DatabaseManager manager) {
-        Validate.notNull(manager, "DatabaseManager is null.");
+        Preconditions.checkNotNull(manager, "DatabaseManager is null.");
         synchronized (players) {
             for (UUID u : players) {
                 if (manager.isLoadedAndOnline(u)) {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/impl/MySQL.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/impl/MySQL.java
@@ -5,10 +5,10 @@ import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.IllegalKeyException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.UserNotRegisteredException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
+import com.google.common.base.Preconditions;
 import net.byteflux.libby.Library;
 import net.byteflux.libby.LibraryManager;
 import net.byteflux.libby.classloader.IsolatedClassLoader;
-import org.apache.commons.lang.Validate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
@@ -55,15 +55,15 @@ public class MySQL implements IDatabase {
      * @throws Exception If anything goes wrong.
      */
     public MySQL(@NotNull String username, @NotNull String password, @NotNull String databaseName, @NotNull String host, @Range(from = 1, to = Integer.MAX_VALUE) int port, @Range(from = 1, to = Integer.MAX_VALUE) int poolSize, @Range(from = 250, to = Long.MAX_VALUE) long connectionTimeout, @NotNull Logger logger, @NotNull LibraryManager manager) throws Exception {
-        Validate.notNull(username, "Username is null.");
-        Validate.notNull(password, "Password is null.");
-        Validate.notNull(databaseName, "Database name is null.");
-        Validate.notNull(host, "Host is null.");
-        Validate.isTrue(port > 0, "Port must be greater than zero.");
-        Validate.isTrue(poolSize > 0, "Pool size must be greater than zero.");
-        Validate.isTrue(connectionTimeout >= 250, "Connection timeout must be greater or equals to 250.");
-        Validate.notNull(logger, "Logger is null.");
-        Validate.notNull(manager, "LibraryManager is null.");
+        Preconditions.checkNotNull(username, "Username is null.");
+        Preconditions.checkNotNull(password, "Password is null.");
+        Preconditions.checkNotNull(databaseName, "Database name is null.");
+        Preconditions.checkNotNull(host, "Host is null.");
+        Preconditions.checkArgument(port > 0, "Port must be greater than zero.");
+        Preconditions.checkArgument(poolSize > 0, "Pool size must be greater than zero.");
+        Preconditions.checkArgument(connectionTimeout >= 250, "Connection timeout must be greater or equals to 250.");
+        Preconditions.checkNotNull(logger, "Logger is null.");
+        Preconditions.checkNotNull(manager, "LibraryManager is null.");
 
         classLoader = new IsolatedClassLoader();
         classLoader.addPath(manager.downloadLibrary(Library.builder().groupId("org.slf4j").artifactId("slf4j-api").version("1.7.30").checksum("zboHlk0btAoHYUhcax6ML4/Z6x0ZxTkorA1/lRAQXFc=").build()));

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/impl/SQLite.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/impl/SQLite.java
@@ -5,7 +5,7 @@ import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.IllegalKeyException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.UserNotRegisteredException;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 import org.sqlite.SQLiteConfig;
@@ -45,8 +45,8 @@ public class SQLite implements IDatabase {
      * @throws Exception If anything goes wrong.
      */
     public SQLite(@NotNull File dbFile, @NotNull Logger logger) throws Exception {
-        Validate.notNull(dbFile, "Database file is null.");
-        Validate.notNull(logger, "Logger is null.");
+        Preconditions.checkNotNull(dbFile, "Database file is null.");
+        Preconditions.checkNotNull(logger, "Logger is null.");
         if (!dbFile.exists() && !dbFile.createNewFile()) {
             throw new IOException("Cannot create the database file.");
         }
@@ -66,7 +66,7 @@ public class SQLite implements IDatabase {
      * @throws Exception If anything goes wrong.
      */
     protected SQLite(@NotNull Logger logger) throws Exception {
-        Validate.notNull(logger, "Logger is null.");
+        Preconditions.checkNotNull(logger, "Logger is null.");
         Class.forName("org.sqlite.JDBC");
         SQLiteConfig config = new SQLiteConfig();
         config.enforceForeignKeys(true);

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/PlayerLoadingCompletedEvent.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/PlayerLoadingCompletedEvent.java
@@ -1,7 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI.events;
 
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/team/TeamLoadEvent.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/team/TeamLoadEvent.java
@@ -2,7 +2,6 @@ package com.fren_gor.ultimateAdvancementAPI.events.team;
 
 import com.fren_gor.ultimateAdvancementAPI.database.DatabaseManager;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/team/TeamUnloadEvent.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/team/TeamUnloadEvent.java
@@ -2,7 +2,7 @@ package com.fren_gor.ultimateAdvancementAPI.events.team;
 
 import com.fren_gor.ultimateAdvancementAPI.database.DatabaseManager;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +25,7 @@ public class TeamUnloadEvent extends Event {
      * @param team The {@link TeamProgression} of the unloaded team. It must be invalid (see {@link TeamProgression#isValid()}).
      */
     public TeamUnloadEvent(@NotNull TeamProgression team) {
-        Validate.isTrue(!Objects.requireNonNull(team, "TeamProgression is null.").isValid(), "TeamProgression is valid.");
+        Preconditions.checkArgument(!Objects.requireNonNull(team, "TeamProgression is null.").isValid(), "TeamProgression is valid.");
         this.team = team;
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/team/TeamUpdateEvent.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/team/TeamUpdateEvent.java
@@ -1,7 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI.events.team;
 
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/exceptions/AsyncExecutionException.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/exceptions/AsyncExecutionException.java
@@ -1,0 +1,27 @@
+package com.fren_gor.ultimateAdvancementAPI.exceptions;
+
+/**
+ * This exception is thrown when some code which should be executed sync is executed async instead.
+ */
+public class AsyncExecutionException extends RuntimeException {
+
+    public AsyncExecutionException() {
+        super();
+    }
+
+    public AsyncExecutionException(String message) {
+        super(message);
+    }
+
+    public AsyncExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AsyncExecutionException(Throwable cause) {
+        super(cause);
+    }
+
+    protected AsyncExecutionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementKey.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementKey.java
@@ -2,7 +2,7 @@ package com.fren_gor.ultimateAdvancementAPI.util;
 
 import com.fren_gor.ultimateAdvancementAPI.exceptions.IllegalKeyException;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
@@ -150,8 +150,8 @@ public final class AdvancementKey implements Comparable<AdvancementKey> {
      * @throws IllegalKeyException If the provided string is longer than 127 characters.
      */
     public static void checkNamespace(String namespace) throws IllegalArgumentException, IllegalKeyException {
-        Validate.notNull(namespace, "Namespace is null.");
-        Validate.isTrue(!namespace.isEmpty(), "Namespace is empty.");
+        Preconditions.checkNotNull(namespace, "Namespace is null.");
+        Preconditions.checkArgument(!namespace.isEmpty(), "Namespace is empty.");
         if (namespace.length() > 127) {
             throw new IllegalKeyException("Too long namespace (max allowed is 127 chars).");
         }
@@ -165,8 +165,8 @@ public final class AdvancementKey implements Comparable<AdvancementKey> {
      * @throws IllegalKeyException If the provided string is longer than 127 characters.
      */
     public static void checkKey(String key) throws IllegalArgumentException, IllegalKeyException {
-        Validate.notNull(key, "Key is null.");
-        Validate.isTrue(!key.isEmpty(), "Key is empty.");
+        Preconditions.checkNotNull(key, "Key is null.");
+        Preconditions.checkArgument(!key.isEmpty(), "Key is empty.");
         if (key.length() > 127) {
             throw new IllegalKeyException("Too long key (max allowed is 127 chars).");
         }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -7,6 +7,7 @@ import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementDisplay;
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
+import com.fren_gor.ultimateAdvancementAPI.exceptions.AsyncExecutionException;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.UserNotLoadedException;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.VanillaAdvancementDisablerWrapper;
@@ -226,7 +227,7 @@ public class AdvancementUtils {
 
     public static void checkSync() {
         if (!Bukkit.isPrimaryThread())
-            throw new IllegalStateException("Illegal async method call. This method can be called only from the main thread.");
+            throw new AsyncExecutionException("Illegal async method call. This method can be called only from the main thread.");
     }
 
     public static void runSync(@NotNull AdvancementMain main, @NotNull Runnable runnable) {

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -14,11 +14,11 @@ import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementD
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutAdvancementsWrapper;
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.ComponentBuilder.FormatRetention;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -61,11 +61,11 @@ public class AdvancementUtils {
      * @see UltimateAdvancementAPI#displayCustomToast(Player, ItemStack, String, AdvancementFrameType)
      */
     public static void displayToast(@NotNull Player player, @NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(icon, "Icon is null.");
-        Validate.notNull(title, "Title is null.");
-        Validate.notNull(frame, "AdvancementFrameType is null.");
-        Validate.isTrue(icon.getType() != Material.AIR, "ItemStack is air.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(icon, "Icon is null.");
+        Preconditions.checkNotNull(title, "Title is null.");
+        Preconditions.checkNotNull(frame, "AdvancementFrameType is null.");
+        Preconditions.checkArgument(icon.getType() != Material.AIR, "ItemStack is air.");
 
         try {
             AdvancementDisplayWrapper display = AdvancementDisplayWrapper.craft(icon, title, ADV_DESCRIPTION, frame.getNMSWrapper(), 1, 0, true, false, false);
@@ -81,13 +81,13 @@ public class AdvancementUtils {
     }
 
     /*public static void displayToast(@NotNull Player player, @NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, @NotNull Advancement base) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(icon, "Icon is null.");
-        Validate.notNull(title, "Title is null.");
-        Validate.notNull(frame, "AdvancementFrameType is null.");
-        Validate.notNull(base, "Advancement is null.");
-        Validate.isTrue(base.isValid(), "Advancement isn't valid.");
-        Validate.isTrue(icon.getType() != Material.AIR, "ItemStack is air.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(icon, "Icon is null.");
+        Preconditions.checkNotNull(title, "Title is null.");
+        Preconditions.checkNotNull(frame, "AdvancementFrameType is null.");
+        Preconditions.checkNotNull(base, "Advancement is null.");
+        Preconditions.checkArgument(base.isValid(), "Advancement isn't valid.");
+        Preconditions.checkArgument(icon.getType() != Material.AIR, "ItemStack is air.");
 
         final MinecraftKeyWrapper key = getUniqueKey(base.getAdvancementTab()).getNMSWrapper();
 
@@ -105,9 +105,9 @@ public class AdvancementUtils {
     }*/
 
     public static void displayToastDuringUpdate(@NotNull Player player, @NotNull Advancement advancement) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.isTrue(advancement.isValid(), "Advancement isn't valid.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkArgument(advancement.isValid(), "Advancement isn't valid.");
 
         final AdvancementDisplay display = advancement.getDisplay();
         final MinecraftKeyWrapper keyWrapper = getUniqueKey(advancement.getAdvancementTab()).getNMSWrapper();
@@ -123,7 +123,8 @@ public class AdvancementUtils {
         }
     }
 
-    private static AdvancementKey getUniqueKey(AdvancementTab tab) {
+    @NotNull
+    private static AdvancementKey getUniqueKey(@NotNull AdvancementTab tab) {
         final String namespace = tab.getNamespace();
         StringBuilder builder = new StringBuilder("i");
         AdvancementKey key;
@@ -150,7 +151,7 @@ public class AdvancementUtils {
 
     @NotNull
     public static BaseComponent[] fromStringList(@Nullable String title, @NotNull List<String> list) {
-        Validate.notNull(list);
+        Preconditions.checkNotNull(list);
         ComponentBuilder builder = new ComponentBuilder();
         if (title != null) {
             builder.append(TextComponent.fromLegacyText(title), FormatRetention.NONE);
@@ -171,7 +172,7 @@ public class AdvancementUtils {
     }
 
     public static boolean startsWithEmptyLine(@NotNull String text) {
-        Validate.notNull(text);
+        Preconditions.checkNotNull(text);
         for (int i = 0; i < text.length(); i++) {
             char c = text.charAt(i);
             if (c == '§') {
@@ -206,8 +207,8 @@ public class AdvancementUtils {
 
     @Contract("null -> fail; !null -> param1")
     public static TeamProgression validateTeamProgression(TeamProgression pro) {
-        Validate.notNull(pro, "TeamProgression is null.");
-        Validate.isTrue(pro.isValid(), "Invalid TeamProgression.");
+        Preconditions.checkNotNull(pro, "TeamProgression is null.");
+        Preconditions.checkArgument(pro.isValid(), "Invalid TeamProgression.");
         return pro;
     }
 
@@ -224,7 +225,8 @@ public class AdvancementUtils {
     }
 
     public static void checkSync() {
-        Validate.isTrue(Bukkit.isPrimaryThread(), "Illegal async method call.");
+        if (!Bukkit.isPrimaryThread())
+            throw new IllegalStateException("Illegal async method call. This method can be called only from the main thread.");
     }
 
     public static void runSync(@NotNull AdvancementMain main, @NotNull Runnable runnable) {
@@ -240,20 +242,20 @@ public class AdvancementUtils {
     }
 
     public static void runSync(@NotNull Plugin plugin, long delay, @NotNull Runnable runnable) {
-        Validate.notNull(plugin, "Plugin is null.");
-        Validate.notNull(runnable, "Runnable is null.");
+        Preconditions.checkNotNull(plugin, "Plugin is null.");
+        Preconditions.checkNotNull(runnable, "Runnable is null.");
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, runnable, delay);
     }
 
     @NotNull
     public static UUID uuidFromPlayer(@NotNull Player player) {
-        Validate.notNull(player, "Player is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
         return player.getUniqueId();
     }
 
     @NotNull
     public static UUID uuidFromPlayer(@NotNull OfflinePlayer player) {
-        Validate.notNull(player, "OfflinePlayer is null.");
+        Preconditions.checkNotNull(player, "OfflinePlayer is null.");
         return player.getUniqueId();
     }
 
@@ -274,7 +276,7 @@ public class AdvancementUtils {
 
     @NotNull
     public static TeamProgression progressionFromUUID(@NotNull UUID uuid, @NotNull AdvancementTab tab) {
-        Validate.notNull(uuid, "UUID is null.");
+        Preconditions.checkNotNull(uuid, "UUID is null.");
         return tab.getDatabaseManager().getTeamProgression(uuid);
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  */
 public class Versions {
 
-    private static final String API_VERSION = "2.0.2";
+    private static final String API_VERSION = "2.0.3";
 
     private static final List<String> SUPPORTED_NMS_VERSIONS = List.of("v1_15_R1", "v1_16_R1", "v1_16_R2", "v1_16_R3", "v1_17_R1", "v1_18_R1");
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/visibilities/HiddenVisibility.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/visibilities/HiddenVisibility.java
@@ -2,7 +2,7 @@ package com.fren_gor.ultimateAdvancementAPI.visibilities;
 
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -20,8 +20,8 @@ public interface HiddenVisibility extends IVisibility {
      */
     @Override
     default boolean isVisible(@NotNull Advancement advancement, @NotNull TeamProgression progression) {
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.notNull(progression, "TeamProgression is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(progression, "TeamProgression is null.");
         return advancement.getProgression(progression) > 0;
     }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/visibilities/ParentGrantedVisibility.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/visibilities/ParentGrantedVisibility.java
@@ -4,7 +4,7 @@ import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.multiParents.AbstractMultiParentsAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,8 +22,8 @@ public interface ParentGrantedVisibility extends IVisibility {
      */
     @Override
     default boolean isVisible(@NotNull Advancement advancement, @NotNull TeamProgression progression) {
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.notNull(progression, "TeamProgression is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(progression, "TeamProgression is null.");
         if (advancement.getProgression(progression) > 0)
             return true;
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/visibilities/VanillaVisibility.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/visibilities/VanillaVisibility.java
@@ -4,7 +4,7 @@ import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.multiParents.AbstractMultiParentsAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,8 +22,8 @@ public interface VanillaVisibility extends IVisibility {
      */
     @Override
     default boolean isVisible(@NotNull Advancement advancement, @NotNull TeamProgression progression) {
-        Validate.notNull(advancement, "Advancement is null.");
-        Validate.notNull(progression, "TeamProgression is null.");
+        Preconditions.checkNotNull(advancement, "Advancement is null.");
+        Preconditions.checkNotNull(progression, "TeamProgression is null.");
         if (advancement.getProgression(progression) > 0)
             return true;
 

--- a/Distribution/API/pom.xml
+++ b/Distribution/API/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi</artifactId>
     <name>UltimateAdvancementAPI</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Distribution/Commands/pom.xml
+++ b/Distribution/Commands/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands</artifactId>
     <name>UltimateAdvancementAPI-Commands</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Distribution/Shadeable/pom.xml
+++ b/Distribution/Shadeable/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-shadeable</artifactId>
     <name>UltimateAdvancementAPI-Shadeable</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_15_R1/pom.xml
+++ b/NMS/1_15_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_15_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_15_R1</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/Util.java
+++ b/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/Util.java
@@ -1,12 +1,12 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_15_R1;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import net.minecraft.server.v1_15_R1.AdvancementProgress;
 import net.minecraft.server.v1_15_R1.Criterion;
 import net.minecraft.server.v1_15_R1.CriterionProgress;
 import net.minecraft.server.v1_15_R1.CriterionTriggerImpossible;
 import net.minecraft.server.v1_15_R1.Packet;
-import org.apache.commons.lang.Validate;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +18,7 @@ public class Util {
 
     @NotNull
     public static Map<String, Criterion> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgressions) {
-        Validate.isTrue(maxProgressions >= 1, "Max progressions must be >= 1.");
+        Preconditions.checkArgument(maxProgressions >= 1, "Max progressions must be >= 1.");
 
         Map<String, Criterion> advCriteria = Maps.newHashMapWithExpectedSize(maxProgressions);
         for (int i = 0; i < maxProgressions; i++) {
@@ -30,7 +30,7 @@ public class Util {
 
     @NotNull
     public static String[][] getAdvancementRequirements(@NotNull Map<String, Criterion> advCriteria) {
-        Validate.notNull(advCriteria, "Advancement criteria map is null.");
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
 
         String[][] array = new String[advCriteria.size()][1];
         int index = 0;
@@ -43,8 +43,8 @@ public class Util {
 
     @NotNull
     public static net.minecraft.server.v1_15_R1.AdvancementProgress getAdvancementProgress(@NotNull net.minecraft.server.v1_15_R1.Advancement mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(mcAdv, "NMS Advancement is null.");
-        Validate.isTrue(progression >= 0, "Progression must be >= 0.");
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
 
         AdvancementProgress advPrg = new AdvancementProgress();
         advPrg.a(mcAdv.getCriteria(), mcAdv.i());
@@ -60,8 +60,8 @@ public class Util {
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(packet, "Packet is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
         ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
     }
 

--- a/NMS/1_16_R1/pom.xml
+++ b/NMS/1_16_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R1</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/Util.java
+++ b/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/Util.java
@@ -1,12 +1,12 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_16_R1;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import net.minecraft.server.v1_16_R1.AdvancementProgress;
 import net.minecraft.server.v1_16_R1.Criterion;
 import net.minecraft.server.v1_16_R1.CriterionProgress;
 import net.minecraft.server.v1_16_R1.CriterionTriggerImpossible;
 import net.minecraft.server.v1_16_R1.Packet;
-import org.apache.commons.lang.Validate;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +18,7 @@ public class Util {
 
     @NotNull
     public static Map<String, Criterion> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
-        Validate.isTrue(maxProgression >= 1, "Max progression must be >= 1.");
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
 
         Map<String, Criterion> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
         for (int i = 0; i < maxProgression; i++) {
@@ -30,7 +30,7 @@ public class Util {
 
     @NotNull
     public static String[][] getAdvancementRequirements(@NotNull Map<String, Criterion> advCriteria) {
-        Validate.notNull(advCriteria, "Advancement criteria map is null.");
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
 
         String[][] array = new String[advCriteria.size()][1];
         int index = 0;
@@ -43,8 +43,8 @@ public class Util {
 
     @NotNull
     public static net.minecraft.server.v1_16_R1.AdvancementProgress getAdvancementProgress(@NotNull net.minecraft.server.v1_16_R1.Advancement mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(mcAdv, "NMS Advancement is null.");
-        Validate.isTrue(progression >= 0, "Progression must be >= 0.");
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
 
         AdvancementProgress advPrg = new AdvancementProgress();
         advPrg.a(mcAdv.getCriteria(), mcAdv.i());
@@ -60,8 +60,8 @@ public class Util {
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(packet, "Packet is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
         ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
     }
 

--- a/NMS/1_16_R2/pom.xml
+++ b/NMS/1_16_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R2</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/Util.java
+++ b/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/Util.java
@@ -1,12 +1,12 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_16_R2;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import net.minecraft.server.v1_16_R2.AdvancementProgress;
 import net.minecraft.server.v1_16_R2.Criterion;
 import net.minecraft.server.v1_16_R2.CriterionProgress;
 import net.minecraft.server.v1_16_R2.CriterionTriggerImpossible;
 import net.minecraft.server.v1_16_R2.Packet;
-import org.apache.commons.lang.Validate;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +18,7 @@ public class Util {
 
     @NotNull
     public static Map<String, Criterion> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
-        Validate.isTrue(maxProgression >= 1, "Max progression must be >= 1.");
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
 
         Map<String, Criterion> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
         for (int i = 0; i < maxProgression; i++) {
@@ -30,7 +30,7 @@ public class Util {
 
     @NotNull
     public static String[][] getAdvancementRequirements(@NotNull Map<String, Criterion> advCriteria) {
-        Validate.notNull(advCriteria, "Advancement criteria map is null.");
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
 
         String[][] array = new String[advCriteria.size()][1];
         int index = 0;
@@ -43,8 +43,8 @@ public class Util {
 
     @NotNull
     public static net.minecraft.server.v1_16_R2.AdvancementProgress getAdvancementProgress(@NotNull net.minecraft.server.v1_16_R2.Advancement mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(mcAdv, "NMS Advancement is null.");
-        Validate.isTrue(progression >= 0, "Progression must be >= 0.");
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
 
         AdvancementProgress advPrg = new AdvancementProgress();
         advPrg.a(mcAdv.getCriteria(), mcAdv.i());
@@ -60,8 +60,8 @@ public class Util {
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(packet, "Packet is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
         ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
     }
 

--- a/NMS/1_16_R3/pom.xml
+++ b/NMS/1_16_R3/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R3</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R3</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/Util.java
+++ b/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/Util.java
@@ -1,12 +1,12 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_16_R3;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import net.minecraft.server.v1_16_R3.AdvancementProgress;
 import net.minecraft.server.v1_16_R3.Criterion;
 import net.minecraft.server.v1_16_R3.CriterionProgress;
 import net.minecraft.server.v1_16_R3.CriterionTriggerImpossible;
 import net.minecraft.server.v1_16_R3.Packet;
-import org.apache.commons.lang.Validate;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +18,7 @@ public class Util {
 
     @NotNull
     public static Map<String, Criterion> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
-        Validate.isTrue(maxProgression >= 1, "Max progression must be >= 1.");
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
 
         Map<String, Criterion> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
         for (int i = 0; i < maxProgression; i++) {
@@ -30,7 +30,7 @@ public class Util {
 
     @NotNull
     public static String[][] getAdvancementRequirements(@NotNull Map<String, Criterion> advCriteria) {
-        Validate.notNull(advCriteria, "Advancement criteria map is null.");
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
 
         String[][] array = new String[advCriteria.size()][1];
         int index = 0;
@@ -43,8 +43,8 @@ public class Util {
 
     @NotNull
     public static net.minecraft.server.v1_16_R3.AdvancementProgress getAdvancementProgress(@NotNull net.minecraft.server.v1_16_R3.Advancement mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(mcAdv, "NMS Advancement is null.");
-        Validate.isTrue(progression >= 0, "Progression must be >= 0.");
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
 
         AdvancementProgress advPrg = new AdvancementProgress();
         advPrg.a(mcAdv.getCriteria(), mcAdv.i());
@@ -60,8 +60,8 @@ public class Util {
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(packet, "Packet is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
         ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
     }
 

--- a/NMS/1_17_R1/pom.xml
+++ b/NMS/1_17_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_17_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_17_R1</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/Util.java
+++ b/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/Util.java
@@ -1,5 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_17_R1;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
@@ -7,7 +8,6 @@ import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.CriterionProgress;
 import net.minecraft.advancements.critereon.ImpossibleTrigger;
 import net.minecraft.network.protocol.Packet;
-import org.apache.commons.lang.Validate;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -19,7 +19,7 @@ public class Util {
 
     @NotNull
     public static Map<String, Criterion> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
-        Validate.isTrue(maxProgression >= 1, "Max progression must be >= 1.");
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
 
         Map<String, Criterion> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
         for (int i = 0; i < maxProgression; i++) {
@@ -31,7 +31,7 @@ public class Util {
 
     @NotNull
     public static String[][] getAdvancementRequirements(@NotNull Map<String, Criterion> advCriteria) {
-        Validate.notNull(advCriteria, "Advancement criteria map is null.");
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
 
         String[][] array = new String[advCriteria.size()][1];
         int index = 0;
@@ -44,8 +44,8 @@ public class Util {
 
     @NotNull
     public static AdvancementProgress getAdvancementProgress(@NotNull Advancement mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(mcAdv, "NMS Advancement is null.");
-        Validate.isTrue(progression >= 0, "Progression must be >= 0.");
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
 
         AdvancementProgress advPrg = new AdvancementProgress();
         advPrg.update(mcAdv.getCriteria(), mcAdv.getRequirements());
@@ -61,8 +61,8 @@ public class Util {
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(packet, "Packet is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
         ((CraftPlayer) player).getHandle().connection.send(packet);
     }
 

--- a/NMS/1_18_R1/pom.xml
+++ b/NMS/1_18_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_18_R1</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/Util.java
+++ b/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/Util.java
@@ -1,5 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_18_R1;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
@@ -7,7 +8,6 @@ import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.CriterionProgress;
 import net.minecraft.advancements.critereon.ImpossibleTrigger;
 import net.minecraft.network.protocol.Packet;
-import org.apache.commons.lang.Validate;
 import org.bukkit.craftbukkit.v1_18_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -19,7 +19,7 @@ public class Util {
 
     @NotNull
     public static Map<String, Criterion> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
-        Validate.isTrue(maxProgression >= 1, "Max progression must be >= 1.");
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
 
         Map<String, Criterion> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
         for (int i = 0; i < maxProgression; i++) {
@@ -31,7 +31,7 @@ public class Util {
 
     @NotNull
     public static String[][] getAdvancementRequirements(@NotNull Map<String, Criterion> advCriteria) {
-        Validate.notNull(advCriteria, "Advancement criteria map is null.");
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
 
         String[][] array = new String[advCriteria.size()][1];
         int index = 0;
@@ -44,8 +44,8 @@ public class Util {
 
     @NotNull
     public static AdvancementProgress getAdvancementProgress(@NotNull Advancement mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
-        Validate.notNull(mcAdv, "NMS Advancement is null.");
-        Validate.isTrue(progression >= 0, "Progression must be >= 0.");
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
 
         AdvancementProgress advPrg = new AdvancementProgress();
         advPrg.update(mcAdv.getCriteria(), mcAdv.getRequirements());
@@ -61,8 +61,8 @@ public class Util {
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
-        Validate.notNull(player, "Player is null.");
-        Validate.notNull(packet, "Packet is null.");
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
         ((CraftPlayer) player).getHandle().connection.send(packet);
     }
 

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-common</artifactId>
     <name>UltimateAdvancementAPI-NMS-Common</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ListSet.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ListSet.java
@@ -1,7 +1,7 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.util;
 
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.AbstractWrapper;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
@@ -33,7 +33,7 @@ public final class ListSet<E> extends AbstractSet<E> implements Set<E> {
      * @throws IllegalArgumentException If the provided {@link Set} is {@code null}.
      */
     public ListSet(@NotNull Set<E> elements) {
-        Validate.notNull(elements, "Set is null.");
+        Preconditions.checkNotNull(elements, "Set is null.");
         @SuppressWarnings("unchecked")
         E[] array = (E[]) new Object[elements.size()];
         int i = 0;
@@ -62,7 +62,7 @@ public final class ListSet<E> extends AbstractSet<E> implements Set<E> {
     @NotNull
     @Contract(pure = true, value = "_ -> new")
     public static <T extends AbstractWrapper> ListSet<?> fromWrapperSet(@NotNull Set<T> elements) {
-        Validate.notNull(elements, "Set is null.");
+        Preconditions.checkNotNull(elements, "Set is null.");
         Object[] array = new Object[elements.size()];
         int i = 0;
         for (T t : elements) {

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
@@ -1,7 +1,7 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.wrappers;
 
 import com.fren_gor.ultimateAdvancementAPI.nms.util.ReflectionUtil;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -18,8 +18,8 @@ public class VanillaAdvancementDisablerWrapper {
         assert clazz != null : "Wrapper class is null.";
         try {
             method = clazz.getDeclaredMethod("disableVanillaAdvancements");
-            Validate.isTrue(Modifier.isPublic(method.getModifiers()), "Method disableVanillaAdvancements() is not public.");
-            Validate.isTrue(Modifier.isStatic(method.getModifiers()), "Method disableVanillaAdvancements() is not static.");
+            Preconditions.checkArgument(Modifier.isPublic(method.getModifiers()), "Method disableVanillaAdvancements() is not public.");
+            Preconditions.checkArgument(Modifier.isStatic(method.getModifiers()), "Method disableVanillaAdvancements() is not static.");
         } catch (ReflectiveOperationException e) {
             e.printStackTrace();
         }

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/packets/ISendable.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/packets/ISendable.java
@@ -1,6 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,7 +26,7 @@ public interface ISendable {
      * @throws IllegalArgumentException If the players array is {@code null}.
      */
     default void sendTo(@NotNull Player... players) {
-        Validate.notNull(players, "Players is null.");
+        Preconditions.checkNotNull(players, "Players is null.");
         for (Player p : players) {
             if (p != null)
                 sendTo(p);
@@ -40,7 +40,7 @@ public interface ISendable {
      * @throws IllegalArgumentException If the players collection is {@code null}.
      */
     default void sendTo(@NotNull Collection<Player> players) {
-        Validate.notNull(players, "Collection<Player> is null.");
+        Preconditions.checkNotNull(players, "Collection<Player> is null.");
         for (Player p : players) {
             if (p != null)
                 sendTo(p);

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-distribution</artifactId>
     <name>UltimateAdvancementAPI-NMS-Distribution</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>
     <name>UltimateAdvancementAPI-Plugin</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>
     <name>UltimateAdvancementAPI-Plugin</name>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
@@ -1,6 +1,6 @@
 package com.fren_gor.ultimateAdvancementAPI;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -87,7 +87,7 @@ public class ConfigManager {
     }
 
     public void enable(@NotNull AdvancementMain main) {
-        Validate.notNull(storageType, "Config has not been loaded.");
+        Preconditions.checkNotNull(storageType, "Config has not been loaded.");
 
         switch (storageType) {
             case SQLITE -> main.enableSQLite(new File(plugin.getDataFolder(), sqlLiteDbName));

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/metrics/BStats.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/metrics/BStats.java
@@ -4,6 +4,7 @@ import com.fren_gor.ultimateAdvancementAPI.AdvancementPlugin;
 import com.fren_gor.ultimateAdvancementAPI.util.Versions;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.DrilldownPie;
+import org.bstats.charts.SimplePie;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,8 +24,9 @@ public class BStats {
 
         Metrics metrics = new Metrics(plugin, BSTATS_ID);
 
+        metrics.addCustomChart(new SimplePie("vanilla_advancements", () -> plugin.getConfigManager().getDisableVanillaAdvancements() ? "Disabled" : "Not Disabled"));
+        metrics.addCustomChart(new SimplePie("database_type", () -> plugin.getConfigManager().getStorageType().getFancyName()));
         metrics.addCustomChart(new DrilldownPie("api_-_minecraft_version", () -> apiMcVersions));
-
         metrics.addCustomChart(new DrilldownPie("api_-_nms_version", () -> apiNMSVersions));
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A powerful API to create custom advancements for your minecraft server.
 <dependency>
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
             <artifactId>spigot-api</artifactId>
             <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Mockito -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <!-- Project Properties -->
-        <apiVersion>2.0.2</apiVersion> <!-- Change also in Versions class -->
+        <apiVersion>2.0.3</apiVersion> <!-- Change also in Versions class -->
         <libbyVersion>1.1.4</libbyVersion>
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -98,7 +98,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Spigot 1.17.1 -->
+        <!-- Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <properties>
         <!-- Project Properties -->
         <apiVersion>2.0.2</apiVersion> <!-- Change also in Versions class -->
-        <libbyVersion>1.1.3</libbyVersion>
+        <libbyVersion>1.1.4</libbyVersion>
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,6 @@
             <artifactId>spigot-api</artifactId>
             <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Mockito -->


### PR DESCRIPTION
Improve failing during API enabling: now the disable() method can be called multiple times without throwing any error.
Add bStats chart about whether vanilla advancement feature is enabled or not.
Add bStats chart about used db type.
Replace Apache Commons' Validate class with Guava's Preconditions.