### PR TITLE
Basic builders for advancement displays

### DIFF
--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -387,4 +387,84 @@ public class AdvancementDisplay {
     public float getY() {
         return y;
     }
+
+    /**
+     * A builder for {@link AdvancementDisplay}.
+     */
+    public static class Builder extends AdvancementDisplayBuilder<Builder, AdvancementDisplay> {
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(new ItemStack(icon), title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            this(new ItemStack(icon), title, x, y, description);
+        }
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(icon, title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            super(icon, title, x, y, description);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public AdvancementDisplay build() {
+            if (frame == null) frame = AdvancementFrameType.TASK;
+            if (defaultColor == null) defaultColor = frame.getColor();
+            return new AdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, description);
+        }
+    }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -209,8 +209,8 @@ public class AdvancementDisplay {
         Preconditions.checkNotNull(description, "Description is null.");
         for (String line : description)
             Preconditions.checkNotNull(line, "A line of the description is null.");
-        Preconditions.checkArgument(x >= 0, "x is not null or positive.");
-        Preconditions.checkArgument(y >= 0, "y is not null or positive.");
+        Preconditions.checkArgument(x >= 0, "x is not zero or positive.");
+        Preconditions.checkArgument(y >= 0, "y is not zero or positive.");
 
         this.icon = icon.clone();
         this.title = title;

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -1,0 +1,161 @@
+package com.fren_gor.ultimateAdvancementAPI.advancement.display;
+
+import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * A builder for advancement displays.
+ */
+@SuppressWarnings("unchecked")
+abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, ?>, R extends AdvancementDisplay>  {
+
+    /**
+     * The icon of the advancement in the advancement GUI.
+     */
+    protected final ItemStack icon;
+
+    /**
+     * The title of the advancement.
+     */
+    protected final String title;
+
+    /**
+     * The description of the advancement.
+     */
+    protected final List<String> description;
+
+    /**
+     * The shape of the advancement frame in the advancement GUI.
+     */
+    protected AdvancementFrameType frame;
+
+    /**
+     * The default color of the title and description.
+     */
+    protected ChatColor defaultColor;
+
+    /**
+     * Whether the toast notification should be sent on advancement grant.
+     */
+    protected boolean showToast = false;
+
+    /**
+     * Whether the advancement completion message should be sent on advancement grant.
+     */
+    protected boolean announceChat = false;
+
+    /**
+     * The advancement x coordinate.
+     */
+    protected float x;
+
+    /**
+     * The advancement y coordinate.
+     */
+    protected float y;
+
+    /**
+     * Construct a new builder for the advancement display.
+     * <p>By default, the advancement won't show the toast message, and
+     * won't announce the message in the chat upon completion.
+     * <p>The default frame is {@link AdvancementFrameType#TASK}.
+     *
+     * @param icon The advancement's icon in the advancement GUI.
+     * @param title The title of the advancement.
+     * @param x The advancement x coordinate.
+     * @param y The advancement y coordinate.
+     * @param description The description of the advancement.
+     */
+    protected AdvancementDisplayBuilder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+        this.icon = icon;
+        this.title = title;
+        this.x = x;
+        this.y = y;
+        this.description = description;
+    }
+
+    /**
+     * Offset the current x and y coordinates based on the provided advancement.
+     *
+     * @param advancement The advancement to apply offset from.
+     * @return This builder.
+     */
+    public T offset(@NotNull Advancement advancement) {
+        return offset(advancement.getDisplay());
+    }
+
+    /**
+     * Offset the current x and y coordinates based on the provided advancement display.
+     *
+     * @param display The advancement display to apply offset from.
+     * @return This builder.
+     */
+    public T offset(@NotNull AdvancementDisplay display) {
+        this.x += display.getX();
+        this.y += display.getY();
+        return (T) this;
+    }
+
+    /**
+     * Set the shape of the advancement frame in the advancement GUI.
+     *
+     * @param frame The shape of the advancement frame in the advancement GUI.
+     * @return This builder.
+     */
+    public T frame(@NotNull AdvancementFrameType frame) {
+        this.frame = frame;
+        return (T) this;
+    }
+
+    /**
+     * Set the default color of the title and description.
+     *
+     * @param color The default color of the title and description.
+     * @return This builder.
+     */
+    public T color(@NotNull ChatColor color) {
+        this.defaultColor = color;
+        return (T) this;
+    }
+
+    /**
+     * Set the toast notification to be sent on advancement grant.
+     *
+     * @return This builder.
+     */
+    public T showToast() {
+        this.showToast = true;
+        return (T) this;
+    }
+
+    /**
+     * Set the advancement completion message to be sent on advancement grant.
+     *
+     * @return This builder.
+     */
+    public T announceChat() {
+        this.announceChat = true;
+        return (T) this;
+    }
+
+    /**
+     * Set the toast notification and the advancement completion message
+     * to be sent on advancement grant.
+     *
+     * @return This builder.
+     */
+    public T announceAll() {
+        return (T) showToast().announceChat();
+    }
+
+    /**
+     * Builds the advancement display.
+     *
+     * @return The built advancement display.
+     */
+    public abstract R build();
+}

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -112,13 +112,43 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
     }
 
     /**
-     * Set the default color of the title and description.
+     * Set the shape of the advancement frame to the {@link AdvancementFrameType#TASK}
+     * in the advancement GUI.
      *
-     * @param color The default color of the title and description.
      * @return This builder.
      */
-    public T color(@NotNull ChatColor color) {
-        this.defaultColor = color;
+    public T taskFrame() {
+        return frame(AdvancementFrameType.TASK);
+    }
+
+    /**
+     * Set the shape of the advancement frame to the {@link AdvancementFrameType#GOAL}
+     * in the advancement GUI.
+     *
+     * @return This builder.
+     */
+    public T goalFrame() {
+        return frame(AdvancementFrameType.GOAL);
+    }
+
+    /**
+     * Set the shape of the advancement frame to the {@link AdvancementFrameType#CHALLENGE}
+     * in the advancement GUI.
+     *
+     * @return This builder.
+     */
+    public T challengeFrame() {
+        return frame(AdvancementFrameType.CHALLENGE);
+    }
+
+    /**
+     * Set the default color of the title and description.
+     *
+     * @param defaultColor The default color of the title and description.
+     * @return This builder.
+     */
+    public T defaultColor(@NotNull ChatColor defaultColor) {
+        this.defaultColor = defaultColor;
         return (T) this;
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.ChatColor;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
     /**
      * The description of the advancement.
      */
-    protected final List<String> description;
+    protected List<String> description;
 
     /**
      * The shape of the advancement frame in the advancement GUI.
@@ -76,6 +77,28 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
         this.x = x;
         this.y = y;
         this.description = description;
+    }
+
+    /**
+     * Set the description of the advancement.
+     *
+     * @param description The description of the advancement.
+     * @return This builder.
+     */
+    public T description(@NotNull String... description) {
+        this.description = Arrays.asList(description);
+        return (T) this;
+    }
+
+    /**
+     * Set the description of the advancement.
+     *
+     * @param description The description of the advancement.
+     * @return This builder.
+     */
+    public T description(@NotNull List<String> description) {
+        this.description = description;
+        return (T) this;
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -244,8 +244,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
          * {@inheritDoc}
          */
         @Override
-        public Builder color(@NotNull ChatColor color) {
-            return titleColor(color).descriptionColor(color);
+        public Builder defaultColor(@NotNull ChatColor defaultColor) {
+            return titleColor(defaultColor).descriptionColor(defaultColor);
         }
 
         /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -160,4 +160,125 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
             this.chatDescription[0] = new TextComponent(defaultTitleColor + rawTitle + (AdvancementUtils.startsWithEmptyLine(compactDescription) ? "\n" : "\n\n") + compactDescription);
         }
     }
+
+    /**
+     * A builder for {@link FancyAdvancementDisplay}.
+     */
+    public static class Builder extends AdvancementDisplayBuilder<Builder, FancyAdvancementDisplay> {
+
+        /**
+         * The default color of the title.
+         */
+        private ChatColor defaultTitleColor;
+
+        /**
+         * The default color of the description.
+         */
+        private ChatColor defaultDescriptionColor;
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(new ItemStack(icon), title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            this(new ItemStack(icon), title, x, y, description);
+        }
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(icon, title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            super(icon, title, x, y, description);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Builder color(@NotNull ChatColor color) {
+            return titleColor(color).descriptionColor(color);
+        }
+
+        /**
+         * Set the default color of the title.
+         *
+         * @param titleColor The default color of the title.
+         * @return This builder.
+         */
+        public Builder titleColor(@NotNull ChatColor titleColor) {
+            this.defaultTitleColor = titleColor;
+            return this;
+        }
+
+        /**
+         * Set the default color of the description.
+         *
+         * @param descriptionColor The default color of the description.
+         * @return This builder.
+         */
+        public Builder descriptionColor(@NotNull ChatColor descriptionColor) {
+            this.defaultDescriptionColor = descriptionColor;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public FancyAdvancementDisplay build() {
+            if (frame == null) frame = AdvancementFrameType.TASK;
+            if (defaultTitleColor == null) defaultTitleColor = DEFAULT_TITLE_COLOR;
+            if (defaultDescriptionColor == null) defaultDescriptionColor = DEFAULT_DESCRIPTION_COLOR;
+            return new FancyAdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, defaultTitleColor, defaultDescriptionColor, description);
+        }
+    }
 }

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ main: com.fren_gor.ultimateAdvancementAPI.AdvancementPlugin
 name: UltimateAdvancementAPI
 version: ${apiVersion}
 description: ${project.description}
-author: [fren_gor, EscanorTargaryen]
+authors: [fren_gor, EscanorTargaryen]
 website: ${project.url}
 
 api-version: 1.15


### PR DESCRIPTION
This PR adds builders for `AdvancementDisplay` and `FancyAdvancementDisplay`.
Required options are specified in the constructors, everything else can be configured via builder.
Example usage:
```java
AdvancementDisplay rootDisplay =
   new AdvancementDisplay.Builder(Material.LAVA_BUCKET, "Lava", 0F, 0F, "This is lava", "And it's hot").build();

FancyAdvancementDisplay fancyDisplay =
   new FancyAdvancementDisplay.Builder(Material.WATER_BUCKET, "Water", 1F, 1F).offset(rootDisplay)
         .description("Water", "Good")
         .descriptionColor(ChatColor.AQUA)
         .announceAll()
         .build();

AdvancementDisplay thirdDisplay =
   new AdvancementDisplay.Builder(Material.MILK_BUCKET, "MInk", 2F, 1F).offset(fancyDisplay).goalFrame().build();
```
Also introduces `offset()` method which makes coordinates calculations easier.