### PR TITLE
Basic builders for advancement displays

### DIFF
--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -97,8 +97,8 @@ public class AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public AdvancementDisplay(@NotNull Material icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull String... description) {
@@ -117,8 +117,8 @@ public class AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public AdvancementDisplay(@NotNull Material icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull List<String> description) {
@@ -137,8 +137,8 @@ public class AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public AdvancementDisplay(@NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull String... description) {
@@ -157,8 +157,8 @@ public class AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public AdvancementDisplay(@NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull List<String> description) {
@@ -176,8 +176,8 @@ public class AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param defaultColor The default color of the title and description.
      * @param description The description of the advancement.
      */
@@ -196,8 +196,8 @@ public class AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param defaultColor The default color of the title and description.
      * @param description The description of the advancement.
      */
@@ -394,77 +394,117 @@ public class AdvancementDisplay {
     public static class Builder extends AdvancementDisplayBuilder<Builder, AdvancementDisplay> {
 
         /**
-         * Construct a new builder for the {@link AdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         * The default color of the title and description.
+         */
+        protected ChatColor defaultColor = frame.getColor();
+        private boolean manuallySetDefaultColor = false;
+
+        /**
+         * Creates a new {@code AdvancementDisplay.Builder}.
+         * <p>By default, the advancement display returned by {@link #build()} won't show both the toast message and
+         * the announcement message in the chat upon advancement completion.
+         * <p>The default {@code frame} is {@link AdvancementFrameType#TASK}.
+         * <p>The default {@code defaultColor} is {@link AdvancementFrameType#getColor() AdvancementFrameType.TASK.getColor()}.
          *
          * @param icon The material of the advancement's icon in the advancement GUI.
          * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
          */
-        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull String... description) {
-            this(new ItemStack(icon), title, x, y, Arrays.asList(description));
+        public Builder(@NotNull Material icon, @NotNull String title) {
+            this(new ItemStack(icon), title);
         }
 
         /**
-         * Construct a new builder for the {@link AdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
-         *
-         * @param icon The material of the advancement's icon in the advancement GUI.
-         * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
-         */
-        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
-            this(new ItemStack(icon), title, x, y, description);
-        }
-
-        /**
-         * Construct a new builder for the {@link AdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         * Creates a new {@code AdvancementDisplay.Builder}.
+         * <p>By default, the advancement display returned by {@link #build()} won't show both the toast message and
+         * the announcement message in the chat upon advancement completion.
+         * <p>The default {@code frame} is {@link AdvancementFrameType#TASK}.
+         * <p>The default {@code defaultColor} is {@link AdvancementFrameType#getColor() AdvancementFrameType.TASK.getColor()}.
          *
          * @param icon The advancement's icon in the advancement GUI.
          * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
          */
-        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull String... description) {
-            this(icon, title, x, y, Arrays.asList(description));
+        public Builder(@NotNull ItemStack icon, @NotNull String title) {
+            super(icon, title);
         }
 
         /**
-         * Construct a new builder for the {@link AdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
-         *
-         * @param icon The advancement's icon in the advancement GUI.
-         * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
+         * {@inheritDoc}
+         * <p>If {@link #defaultColor(ChatColor) builder.defaultColor(...)} hasn't been called yet (or if it will never be called),
+         * also sets the {@link #defaultColor default color} to {@link AdvancementFrameType#getColor() frame.getColor()}.
          */
-        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
-            super(icon, title, x, y, description);
+        @Override
+        @NotNull
+        public Builder frame(@NotNull AdvancementFrameType frame) {
+            super.frame(frame); // Also checks frame is not null
+            if (!manuallySetDefaultColor) {
+                this.defaultColor = frame.getColor();
+            }
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         * <p>If {@link #defaultColor(ChatColor) builder.defaultColor(...)} hasn't been called yet (or if it will never be called),
+         * also sets the {@link #defaultColor default color} to {@link AdvancementFrameType#getColor() AdvancementFrameType.TASK.getColor()}.
+         */
+        @Override
+        @NotNull
+        public Builder taskFrame() {
+            return super.taskFrame();
+        }
+
+        /**
+         * {@inheritDoc}
+         * <p>If {@link #defaultColor(ChatColor) builder.defaultColor(...)} hasn't been called yet (or if it will never be called),
+         * also sets the {@link #defaultColor default color} to {@link AdvancementFrameType#getColor() AdvancementFrameType.GOAL.getColor()}.
+         */
+        @Override
+        @NotNull
+        public Builder goalFrame() {
+            return super.goalFrame();
+        }
+
+        /**
+         * {@inheritDoc}
+         * <p>If {@link #defaultColor(ChatColor) builder.defaultColor(...)} hasn't been called yet (or if it will never be called),
+         * also sets the {@link #defaultColor default color} to {@link AdvancementFrameType#getColor() AdvancementFrameType.CHALLENGE.getColor()}.
+         */
+        @Override
+        @NotNull
+        public Builder challengeFrame() {
+            return super.challengeFrame();
+        }
+
+        /**
+         * Sets the default color of the title and description.
+         *
+         * @param defaultColor The default color of the title and description.
+         * @return This builder.
+         */
+        @NotNull
+        public Builder defaultColor(@NotNull ChatColor defaultColor) {
+            this.defaultColor = Objects.requireNonNull(defaultColor, "Default color is null.");
+            manuallySetDefaultColor = true;
+            return this;
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
+        @NotNull
         public AdvancementDisplay build() {
-            if (frame == null) frame = AdvancementFrameType.TASK;
-            if (defaultColor == null) defaultColor = frame.getColor();
             return new AdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, description);
+        }
+
+        /**
+         * Gets the default color of the title and description.
+         *
+         * @return The default color of the title and description.
+         */
+        @NotNull
+        public ChatColor getDefaultColor() {
+            return defaultColor;
         }
     }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -387,4 +387,84 @@ public class AdvancementDisplay {
     public float getY() {
         return y;
     }
+
+    /**
+     * A builder for {@link AdvancementDisplay}.
+     */
+    public static class Builder extends AdvancementDisplayBuilder<Builder, AdvancementDisplay> {
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(new ItemStack(icon), title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            this(new ItemStack(icon), title, x, y, description);
+        }
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(icon, title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link AdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            super(icon, title, x, y, description);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public AdvancementDisplay build() {
+            if (frame == null) frame = AdvancementFrameType.TASK;
+            if (defaultColor == null) defaultColor = frame.getColor();
+            return new AdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, description);
+        }
+    }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -209,8 +209,8 @@ public class AdvancementDisplay {
         Preconditions.checkNotNull(description, "Description is null.");
         for (String line : description)
             Preconditions.checkNotNull(line, "A line of the description is null.");
-        Preconditions.checkArgument(x >= 0, "x is not null or positive.");
-        Preconditions.checkArgument(y >= 0, "y is not null or positive.");
+        Preconditions.checkArgument(x >= 0, "x is not zero or positive.");
+        Preconditions.checkArgument(y >= 0, "y is not zero or positive.");
 
         this.icon = icon.clone();
         this.title = title;

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -397,7 +397,7 @@ public class AdvancementDisplay {
          * The default color of the title and description.
          */
         protected ChatColor defaultColor = frame.getColor();
-        private boolean manuallySetDefaultColor = false;
+        private boolean manuallySetDefaultColor = false; // Set to true when defaultColor(ChatColor) is called
 
         /**
          * Creates a new {@code AdvancementDisplay.Builder}.
@@ -410,7 +410,7 @@ public class AdvancementDisplay {
          * @param title The title of the advancement.
          */
         public Builder(@NotNull Material icon, @NotNull String title) {
-            this(new ItemStack(icon), title);
+            super(icon, title);
         }
 
         /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplay.java
@@ -494,7 +494,7 @@ public class AdvancementDisplay {
         @Override
         @NotNull
         public AdvancementDisplay build() {
-            return new AdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, description);
+            return new AdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, defaultColor, description);
         }
 
         /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -1,0 +1,161 @@
+package com.fren_gor.ultimateAdvancementAPI.advancement.display;
+
+import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * A builder for advancement displays.
+ */
+@SuppressWarnings("unchecked")
+abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, ?>, R extends AdvancementDisplay>  {
+
+    /**
+     * The icon of the advancement in the advancement GUI.
+     */
+    protected final ItemStack icon;
+
+    /**
+     * The title of the advancement.
+     */
+    protected final String title;
+
+    /**
+     * The description of the advancement.
+     */
+    protected final List<String> description;
+
+    /**
+     * The shape of the advancement frame in the advancement GUI.
+     */
+    protected AdvancementFrameType frame;
+
+    /**
+     * The default color of the title and description.
+     */
+    protected ChatColor defaultColor;
+
+    /**
+     * Whether the toast notification should be sent on advancement grant.
+     */
+    protected boolean showToast = false;
+
+    /**
+     * Whether the advancement completion message should be sent on advancement grant.
+     */
+    protected boolean announceChat = false;
+
+    /**
+     * The advancement x coordinate.
+     */
+    protected float x;
+
+    /**
+     * The advancement y coordinate.
+     */
+    protected float y;
+
+    /**
+     * Construct a new builder for the advancement display.
+     * <p>By default, the advancement won't show the toast message, and
+     * won't announce the message in the chat upon completion.
+     * <p>The default frame is {@link AdvancementFrameType#TASK}.
+     *
+     * @param icon The advancement's icon in the advancement GUI.
+     * @param title The title of the advancement.
+     * @param x The advancement x coordinate.
+     * @param y The advancement y coordinate.
+     * @param description The description of the advancement.
+     */
+    protected AdvancementDisplayBuilder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+        this.icon = icon;
+        this.title = title;
+        this.x = x;
+        this.y = y;
+        this.description = description;
+    }
+
+    /**
+     * Offset the current x and y coordinates based on the provided advancement.
+     *
+     * @param advancement The advancement to apply offset from.
+     * @return This builder.
+     */
+    public T offset(@NotNull Advancement advancement) {
+        return offset(advancement.getDisplay());
+    }
+
+    /**
+     * Offset the current x and y coordinates based on the provided advancement display.
+     *
+     * @param display The advancement display to apply offset from.
+     * @return This builder.
+     */
+    public T offset(@NotNull AdvancementDisplay display) {
+        this.x += display.getX();
+        this.y += display.getY();
+        return (T) this;
+    }
+
+    /**
+     * Set the shape of the advancement frame in the advancement GUI.
+     *
+     * @param frame The shape of the advancement frame in the advancement GUI.
+     * @return This builder.
+     */
+    public T frame(@NotNull AdvancementFrameType frame) {
+        this.frame = frame;
+        return (T) this;
+    }
+
+    /**
+     * Set the default color of the title and description.
+     *
+     * @param color The default color of the title and description.
+     * @return This builder.
+     */
+    public T color(@NotNull ChatColor color) {
+        this.defaultColor = color;
+        return (T) this;
+    }
+
+    /**
+     * Set the toast notification to be sent on advancement grant.
+     *
+     * @return This builder.
+     */
+    public T showToast() {
+        this.showToast = true;
+        return (T) this;
+    }
+
+    /**
+     * Set the advancement completion message to be sent on advancement grant.
+     *
+     * @return This builder.
+     */
+    public T announceChat() {
+        this.announceChat = true;
+        return (T) this;
+    }
+
+    /**
+     * Set the toast notification and the advancement completion message
+     * to be sent on advancement grant.
+     *
+     * @return This builder.
+     */
+    public T announceAll() {
+        return (T) showToast().announceChat();
+    }
+
+    /**
+     * Builds the advancement display.
+     *
+     * @return The built advancement display.
+     */
+    public abstract R build();
+}

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -112,13 +112,43 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
     }
 
     /**
-     * Set the default color of the title and description.
+     * Set the shape of the advancement frame to the {@link AdvancementFrameType#TASK}
+     * in the advancement GUI.
      *
-     * @param color The default color of the title and description.
      * @return This builder.
      */
-    public T color(@NotNull ChatColor color) {
-        this.defaultColor = color;
+    public T taskFrame() {
+        return frame(AdvancementFrameType.TASK);
+    }
+
+    /**
+     * Set the shape of the advancement frame to the {@link AdvancementFrameType#GOAL}
+     * in the advancement GUI.
+     *
+     * @return This builder.
+     */
+    public T goalFrame() {
+        return frame(AdvancementFrameType.GOAL);
+    }
+
+    /**
+     * Set the shape of the advancement frame to the {@link AdvancementFrameType#CHALLENGE}
+     * in the advancement GUI.
+     *
+     * @return This builder.
+     */
+    public T challengeFrame() {
+        return frame(AdvancementFrameType.CHALLENGE);
+    }
+
+    /**
+     * Set the default color of the title and description.
+     *
+     * @param defaultColor The default color of the title and description.
+     * @return This builder.
+     */
+    public T defaultColor(@NotNull ChatColor defaultColor) {
+        this.defaultColor = defaultColor;
         return (T) this;
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.ChatColor;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
     /**
      * The description of the advancement.
      */
-    protected final List<String> description;
+    protected List<String> description;
 
     /**
      * The shape of the advancement frame in the advancement GUI.
@@ -76,6 +77,28 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
         this.x = x;
         this.y = y;
         this.description = description;
+    }
+
+    /**
+     * Set the description of the advancement.
+     *
+     * @param description The description of the advancement.
+     * @return This builder.
+     */
+    public T description(@NotNull String... description) {
+        this.description = Arrays.asList(description);
+        return (T) this;
+    }
+
+    /**
+     * Set the description of the advancement.
+     *
+     * @param description The description of the advancement.
+     * @return This builder.
+     */
+    public T description(@NotNull List<String> description) {
+        this.description = description;
+        return (T) this;
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -1,6 +1,7 @@
 package com.fren_gor.ultimateAdvancementAPI.advancement.display;
 
 import com.google.common.base.Preconditions;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
@@ -54,6 +55,20 @@ public abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuil
      * The advancement y coordinate. Must be &gt;= 0.
      */
     protected float y = 0;
+
+    /**
+     * Creates a new {@code AdvancementDisplayBuilder}.
+     * <p>By default, the advancement display returned by {@link #build()} won't show both the toast message and
+     * the announcement message in the chat upon advancement completion.
+     * <p>The default {@code frame} is {@link AdvancementFrameType#TASK}.
+     *
+     * @param icon The material of the advancement's icon in the advancement GUI.
+     * @param title The title of the advancement.
+     */
+    protected AdvancementDisplayBuilder(@NotNull Material icon, @NotNull String title) {
+        this.icon = new ItemStack(Objects.requireNonNull(icon, "Icon is null."));
+        this.title = Objects.requireNonNull(title, "Title is null.");
+    }
 
     /**
      * Creates a new {@code AdvancementDisplayBuilder}.

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -65,7 +65,7 @@ public abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuil
      * @param title The title of the advancement.
      */
     protected AdvancementDisplayBuilder(@NotNull ItemStack icon, @NotNull String title) {
-        this.icon = Objects.requireNonNull(icon, "Icon is null.");
+        this.icon = Objects.requireNonNull(icon, "Icon is null.").clone();
         this.title = Objects.requireNonNull(title, "Title is null.");
     }
 
@@ -238,7 +238,7 @@ public abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuil
      */
     @NotNull
     public ItemStack getIcon() {
-        return icon;
+        return icon.clone();
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/AdvancementDisplayBuilder.java
@@ -1,18 +1,18 @@
 package com.fren_gor.ultimateAdvancementAPI.advancement.display;
 
-import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
-import net.md_5.bungee.api.ChatColor;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A builder for advancement displays.
  */
 @SuppressWarnings("unchecked")
-abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, ?>, R extends AdvancementDisplay>  {
+public abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<T, R>, R extends AdvancementDisplay> {
 
     /**
      * The icon of the advancement in the advancement GUI.
@@ -27,17 +27,13 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
     /**
      * The description of the advancement.
      */
-    protected List<String> description;
+    @Unmodifiable
+    protected List<String> description = List.of();
 
     /**
      * The shape of the advancement frame in the advancement GUI.
      */
-    protected AdvancementFrameType frame;
-
-    /**
-     * The default color of the title and description.
-     */
-    protected ChatColor defaultColor;
+    protected AdvancementFrameType frame = AdvancementFrameType.TASK;
 
     /**
      * Whether the toast notification should be sent on advancement grant.
@@ -50,159 +46,181 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
     protected boolean announceChat = false;
 
     /**
-     * The advancement x coordinate.
+     * The advancement x coordinate. Must be &gt;= 0.
      */
-    protected float x;
+    protected float x = 0;
 
     /**
-     * The advancement y coordinate.
+     * The advancement y coordinate. Must be &gt;= 0.
      */
-    protected float y;
+    protected float y = 0;
 
     /**
-     * Construct a new builder for the advancement display.
-     * <p>By default, the advancement won't show the toast message, and
-     * won't announce the message in the chat upon completion.
-     * <p>The default frame is {@link AdvancementFrameType#TASK}.
+     * Creates a new {@code AdvancementDisplayBuilder}.
+     * <p>By default, the advancement display returned by {@link #build()} won't show both the toast message and
+     * the announcement message in the chat upon advancement completion.
+     * <p>The default {@code frame} is {@link AdvancementFrameType#TASK}.
      *
      * @param icon The advancement's icon in the advancement GUI.
      * @param title The title of the advancement.
-     * @param x The advancement x coordinate.
-     * @param y The advancement y coordinate.
-     * @param description The description of the advancement.
      */
-    protected AdvancementDisplayBuilder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
-        this.icon = icon;
-        this.title = title;
+    protected AdvancementDisplayBuilder(@NotNull ItemStack icon, @NotNull String title) {
+        this.icon = Objects.requireNonNull(icon, "Icon is null.");
+        this.title = Objects.requireNonNull(title, "Title is null.");
+    }
+
+    /**
+     * Sets the x and y coordinates of the advancement in the advancement GUI.
+     * <p>The origin is placed in the upper-left corner of the advancement GUI.
+     * The x-axis points to the right (as usual), whereas the y-axis points downward.
+     * Thus, the x and y coordinates must be positive.
+     *
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
+     * @return This builder.
+     */
+    @NotNull
+    public T coords(float x, float y) {
+        x(x);
+        y(y);
+        return (T) this;
+    }
+
+    /**
+     * Sets the x and y coordinates of the advancement in the advancement GUI.
+     * <p>The origin is placed in the upper-left corner of the advancement GUI. The x-axis points to the right (as usual).
+     *
+     * @param x The advancement x coordinate. Must be not negative.
+     * @return This builder.
+     */
+    @NotNull
+    public T x(float x) {
+        Preconditions.checkArgument(x >= 0, "x is not zero or positive.");
         this.x = x;
+        return (T) this;
+    }
+
+    /**
+     * Sets the y coordinate of the advancement in the advancement GUI.
+     * <p>The origin is placed in the upper-left corner of the advancement GUI. The y-axis points downward.
+     *
+     * @param y The advancement y coordinate. Must be not negative.
+     * @return This builder.
+     */
+    @NotNull
+    public T y(float y) {
+        Preconditions.checkArgument(y >= 0, "y is not zero or positive.");
         this.y = y;
-        this.description = description;
+        return (T) this;
     }
 
     /**
-     * Set the description of the advancement.
+     * Sets the description of the advancement.
      *
      * @param description The description of the advancement.
      * @return This builder.
      */
+    @NotNull
     public T description(@NotNull String... description) {
-        this.description = Arrays.asList(description);
+        this.description = List.of(description);
         return (T) this;
     }
 
     /**
-     * Set the description of the advancement.
+     * Sets the description of the advancement.
      *
      * @param description The description of the advancement.
      * @return This builder.
      */
+    @NotNull
     public T description(@NotNull List<String> description) {
-        this.description = description;
+        this.description = List.copyOf(description);
         return (T) this;
     }
 
     /**
-     * Offset the current x and y coordinates based on the provided advancement.
-     *
-     * @param advancement The advancement to apply offset from.
-     * @return This builder.
-     */
-    public T offset(@NotNull Advancement advancement) {
-        return offset(advancement.getDisplay());
-    }
-
-    /**
-     * Offset the current x and y coordinates based on the provided advancement display.
-     *
-     * @param display The advancement display to apply offset from.
-     * @return This builder.
-     */
-    public T offset(@NotNull AdvancementDisplay display) {
-        this.x += display.getX();
-        this.y += display.getY();
-        return (T) this;
-    }
-
-    /**
-     * Set the shape of the advancement frame in the advancement GUI.
+     * Sets the shape of the advancement frame in the advancement GUI.
      *
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @return This builder.
      */
+    @NotNull
     public T frame(@NotNull AdvancementFrameType frame) {
-        this.frame = frame;
+        this.frame = Objects.requireNonNull(frame, "Frame is null.");
         return (T) this;
     }
 
     /**
-     * Set the shape of the advancement frame to the {@link AdvancementFrameType#TASK}
-     * in the advancement GUI.
+     * Sets the shape of the advancement frame to {@link AdvancementFrameType#TASK}.
      *
      * @return This builder.
      */
+    @NotNull
     public T taskFrame() {
         return frame(AdvancementFrameType.TASK);
     }
 
     /**
-     * Set the shape of the advancement frame to the {@link AdvancementFrameType#GOAL}
-     * in the advancement GUI.
+     * Sets the shape of the advancement frame to {@link AdvancementFrameType#GOAL}.
      *
      * @return This builder.
      */
+    @NotNull
     public T goalFrame() {
         return frame(AdvancementFrameType.GOAL);
     }
 
     /**
-     * Set the shape of the advancement frame to the {@link AdvancementFrameType#CHALLENGE}
-     * in the advancement GUI.
+     * Sets the shape of the advancement frame to {@link AdvancementFrameType#CHALLENGE}.
      *
      * @return This builder.
      */
+    @NotNull
     public T challengeFrame() {
         return frame(AdvancementFrameType.CHALLENGE);
     }
 
     /**
-     * Set the default color of the title and description.
-     *
-     * @param defaultColor The default color of the title and description.
-     * @return This builder.
-     */
-    public T defaultColor(@NotNull ChatColor defaultColor) {
-        this.defaultColor = defaultColor;
-        return (T) this;
-    }
-
-    /**
-     * Set the toast notification to be sent on advancement grant.
+     * Enables the toast notification sent on advancement grant.
      *
      * @return This builder.
      */
+    @NotNull
     public T showToast() {
-        this.showToast = true;
+        return showToast(true);
+    }
+
+    /**
+     * Enables or disables the toast notification sent on advancement grant.
+     *
+     * @param showToast Whether to show the toast notification on advancement grant.
+     * @return This builder.
+     */
+    public T showToast(boolean showToast) {
+        this.showToast = showToast;
         return (T) this;
     }
 
     /**
-     * Set the advancement completion message to be sent on advancement grant.
+     * Enables the advancement completion message sent on advancement grant.
      *
      * @return This builder.
      */
+    @NotNull
     public T announceChat() {
-        this.announceChat = true;
-        return (T) this;
+        return announceChat(true);
     }
 
     /**
-     * Set the toast notification and the advancement completion message
-     * to be sent on advancement grant.
+     * Enables or disables the advancement completion message sent on advancement grant.
      *
+     * @param announceChat Whether to send the advancement completion message on advancement grant.
      * @return This builder.
      */
-    public T announceAll() {
-        return (T) showToast().announceChat();
+    @NotNull
+    public T announceChat(boolean announceChat) {
+        this.announceChat = announceChat;
+        return (T) this;
     }
 
     /**
@@ -210,5 +228,82 @@ abstract class AdvancementDisplayBuilder<T extends AdvancementDisplayBuilder<?, 
      *
      * @return The built advancement display.
      */
+    @NotNull
     public abstract R build();
+
+    /**
+     * Gets the icon of the advancement in the advancement GUI.
+     *
+     * @return The icon of the advancement in the advancement GUI.
+     */
+    @NotNull
+    public ItemStack getIcon() {
+        return icon;
+    }
+
+    /**
+     * Gets the title of the advancement.
+     *
+     * @return The title of the advancement.
+     */
+    @NotNull
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Gets the description of the advancement.
+     *
+     * @return The description of the advancement.
+     */
+    @NotNull
+    public List<String> getDescription() {
+        return description;
+    }
+
+    /**
+     * Gets the shape of the advancement frame in the advancement GUI.
+     *
+     * @return The shape of the advancement frame in the advancement GUI.
+     */
+    @NotNull
+    public AdvancementFrameType getFrame() {
+        return frame;
+    }
+
+    /**
+     * Returns whether the toast notification should be sent on advancement grant.
+     *
+     * @return Whether the toast notification should be sent on advancement grant.
+     */
+    public boolean doesShowToast() {
+        return showToast;
+    }
+
+    /**
+     * Returns whether the advancement completion message should be sent on advancement grant.
+     *
+     * @return Whether the advancement completion message should be sent on advancement grant.
+     */
+    public boolean doesAnnounceToChat() {
+        return announceChat;
+    }
+
+    /**
+     * Returns the advancement position relative to the x-axis.
+     *
+     * @return The x coordinate.
+     */
+    public float getX() {
+        return x;
+    }
+
+    /**
+     * Returns the advancement position relative to the y-axis.
+     *
+     * @return The y coordinate.
+     */
+    public float getY() {
+        return y;
+    }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -45,8 +45,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public FancyAdvancementDisplay(@NotNull Material icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull String... description) {
@@ -64,8 +64,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public FancyAdvancementDisplay(@NotNull Material icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull List<String> description) {
@@ -83,8 +83,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public FancyAdvancementDisplay(@NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull String... description) {
@@ -102,8 +102,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param description The description of the advancement.
      */
     public FancyAdvancementDisplay(@NotNull ItemStack icon, @NotNull String title, @NotNull AdvancementFrameType frame, boolean showToast, boolean announceChat, float x, float y, @NotNull List<String> description) {
@@ -121,8 +121,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param defaultTitleColor The default color of the title.
      * @param defaultDescriptionColor The default color of the description.
      * @param description The description of the advancement.
@@ -142,8 +142,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
      * @param frame The shape of the advancement frame in the advancement GUI.
      * @param showToast Whether the toast notification should be sent on advancement grant.
      * @param announceChat Whether the advancement completion message should be sent on advancement grant.
-     * @param x The advancement x coordinate. Must be positive.
-     * @param y The advancement y coordinate. Must be positive.
+     * @param x The advancement x coordinate. Must be not negative.
+     * @param y The advancement y coordinate. Must be not negative.
      * @param defaultTitleColor The default color of the title.
      * @param defaultDescriptionColor The default color of the description.
      * @param description The description of the advancement.
@@ -169,104 +169,60 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
         /**
          * The default color of the title.
          */
-        private ChatColor defaultTitleColor;
+        protected ChatColor defaultTitleColor = DEFAULT_TITLE_COLOR;
 
         /**
          * The default color of the description.
          */
-        private ChatColor defaultDescriptionColor;
+        protected ChatColor defaultDescriptionColor = DEFAULT_DESCRIPTION_COLOR;
 
         /**
-         * Construct a new builder for the {@link FancyAdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         * Creates a new {@code FancyAdvancementDisplay.Builder}.
+         * <p>By default, the fancy advancement display returned by {@link #build()} won't show both the toast message and
+         * the announcement message in the chat upon advancement completion.
+         * <p>The default {@code frame} is {@link AdvancementFrameType#TASK}.
          *
          * @param icon The material of the advancement's icon in the advancement GUI.
          * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
          */
-        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull String... description) {
-            this(new ItemStack(icon), title, x, y, Arrays.asList(description));
+        public Builder(@NotNull Material icon, @NotNull String title) {
+            this(new ItemStack(icon), title);
         }
 
         /**
-         * Construct a new builder for the {@link FancyAdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
-         *
-         * @param icon The material of the advancement's icon in the advancement GUI.
-         * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
-         */
-        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
-            this(new ItemStack(icon), title, x, y, description);
-        }
-
-        /**
-         * Construct a new builder for the {@link FancyAdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         * Creates a new {@code FancyAdvancementDisplay.Builder}.
+         * <p>By default, the fancy advancement display returned by {@link #build()} won't show both the toast message and
+         * the announcement message in the chat upon advancement completion.
+         * <p>The default {@code frame} is {@link AdvancementFrameType#TASK}.
          *
          * @param icon The advancement's icon in the advancement GUI.
          * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
          */
-        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull String... description) {
-            this(icon, title, x, y, Arrays.asList(description));
+        public Builder(@NotNull ItemStack icon, @NotNull String title) {
+            super(icon, title);
         }
 
         /**
-         * Construct a new builder for the {@link FancyAdvancementDisplay}.
-         * <p>By default, the advancement won't show the toast message, and
-         * won't announce the message in the chat upon completion.
-         * <p>The default frame is {@link AdvancementFrameType#TASK}.
-         *
-         * @param icon The advancement's icon in the advancement GUI.
-         * @param title The title of the advancement.
-         * @param x The advancement x coordinate.
-         * @param y The advancement y coordinate.
-         * @param description The description of the advancement.
-         */
-        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
-            super(icon, title, x, y, description);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public Builder defaultColor(@NotNull ChatColor defaultColor) {
-            return titleColor(defaultColor).descriptionColor(defaultColor);
-        }
-
-        /**
-         * Set the default color of the title.
+         * Sets the default color of the title.
          *
          * @param titleColor The default color of the title.
          * @return This builder.
          */
+        @NotNull
         public Builder titleColor(@NotNull ChatColor titleColor) {
-            this.defaultTitleColor = titleColor;
+            this.defaultTitleColor = Objects.requireNonNull(titleColor, "Default title color is null.");
             return this;
         }
 
         /**
-         * Set the default color of the description.
+         * Sets the default color of the description.
          *
          * @param descriptionColor The default color of the description.
          * @return This builder.
          */
+        @NotNull
         public Builder descriptionColor(@NotNull ChatColor descriptionColor) {
-            this.defaultDescriptionColor = descriptionColor;
+            this.defaultDescriptionColor = Objects.requireNonNull(descriptionColor, "Default description color is null.");
             return this;
         }
 
@@ -274,11 +230,29 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
          * {@inheritDoc}
          */
         @Override
+        @NotNull
         public FancyAdvancementDisplay build() {
-            if (frame == null) frame = AdvancementFrameType.TASK;
-            if (defaultTitleColor == null) defaultTitleColor = DEFAULT_TITLE_COLOR;
-            if (defaultDescriptionColor == null) defaultDescriptionColor = DEFAULT_DESCRIPTION_COLOR;
             return new FancyAdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, defaultTitleColor, defaultDescriptionColor, description);
+        }
+
+        /**
+         * Gets the default color of the title.
+         *
+         * @return The default color of the title.
+         */
+        @NotNull
+        public ChatColor getDefaultTitleColor() {
+            return defaultTitleColor;
+        }
+
+        /**
+         * Gets the default color of the description.
+         *
+         * @return The default color of the description.
+         */
+        @NotNull
+        public ChatColor getDefaultDescriptionColor() {
+            return defaultDescriptionColor;
         }
     }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -244,8 +244,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
          * {@inheritDoc}
          */
         @Override
-        public Builder color(@NotNull ChatColor color) {
-            return titleColor(color).descriptionColor(color);
+        public Builder defaultColor(@NotNull ChatColor defaultColor) {
+            return titleColor(defaultColor).descriptionColor(defaultColor);
         }
 
         /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -160,4 +160,125 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
             this.chatDescription[0] = new TextComponent(defaultTitleColor + rawTitle + (AdvancementUtils.startsWithEmptyLine(compactDescription) ? "\n" : "\n\n") + compactDescription);
         }
     }
+
+    /**
+     * A builder for {@link FancyAdvancementDisplay}.
+     */
+    public static class Builder extends AdvancementDisplayBuilder<Builder, FancyAdvancementDisplay> {
+
+        /**
+         * The default color of the title.
+         */
+        private ChatColor defaultTitleColor;
+
+        /**
+         * The default color of the description.
+         */
+        private ChatColor defaultDescriptionColor;
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(new ItemStack(icon), title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The material of the advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull Material icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            this(new ItemStack(icon), title, x, y, description);
+        }
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull String... description) {
+            this(icon, title, x, y, Arrays.asList(description));
+        }
+
+        /**
+         * Construct a new builder for the {@link FancyAdvancementDisplay}.
+         * <p>By default, the advancement won't show the toast message, and
+         * won't announce the message in the chat upon completion.
+         * <p>The default frame is {@link AdvancementFrameType#TASK}.
+         *
+         * @param icon The advancement's icon in the advancement GUI.
+         * @param title The title of the advancement.
+         * @param x The advancement x coordinate.
+         * @param y The advancement y coordinate.
+         * @param description The description of the advancement.
+         */
+        public Builder(@NotNull ItemStack icon, @NotNull String title, float x, float y, @NotNull List<String> description) {
+            super(icon, title, x, y, description);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Builder color(@NotNull ChatColor color) {
+            return titleColor(color).descriptionColor(color);
+        }
+
+        /**
+         * Set the default color of the title.
+         *
+         * @param titleColor The default color of the title.
+         * @return This builder.
+         */
+        public Builder titleColor(@NotNull ChatColor titleColor) {
+            this.defaultTitleColor = titleColor;
+            return this;
+        }
+
+        /**
+         * Set the default color of the description.
+         *
+         * @param descriptionColor The default color of the description.
+         * @return This builder.
+         */
+        public Builder descriptionColor(@NotNull ChatColor descriptionColor) {
+            this.defaultDescriptionColor = descriptionColor;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public FancyAdvancementDisplay build() {
+            if (frame == null) frame = AdvancementFrameType.TASK;
+            if (defaultTitleColor == null) defaultTitleColor = DEFAULT_TITLE_COLOR;
+            if (defaultDescriptionColor == null) defaultDescriptionColor = DEFAULT_DESCRIPTION_COLOR;
+            return new FancyAdvancementDisplay(icon, title, frame, showToast, announceChat, x, y, defaultTitleColor, defaultDescriptionColor, description);
+        }
+    }
 }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -186,7 +186,7 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
          * @param title The title of the advancement.
          */
         public Builder(@NotNull Material icon, @NotNull String title) {
-            this(new ItemStack(icon), title);
+            super(icon, title);
         }
 
         /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/TaskAdvancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/TaskAdvancement.java
@@ -2,7 +2,6 @@ package com.fren_gor.ultimateAdvancementAPI.advancement.tasks;
 
 import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementDisplay;
-import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
 import com.fren_gor.ultimateAdvancementAPI.database.DatabaseManager;
 import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
 import com.fren_gor.ultimateAdvancementAPI.events.advancement.AdvancementProgressionUpdateEvent;
@@ -53,7 +52,7 @@ public class TaskAdvancement extends BaseAdvancement {
      * @param maxProgression The maximum progression of the task.
      */
     public TaskAdvancement(@NotNull String key, @NotNull AbstractMultiTasksAdvancement multitask, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
-        this(key, new AdvancementDisplay(Material.GRASS_BLOCK, Objects.requireNonNull(key, "Key is null."), AdvancementFrameType.TASK, false, false, 0, 0), multitask, maxProgression);
+        this(key, new AdvancementDisplay.Builder(Material.GRASS_BLOCK, Objects.requireNonNull(key, "Key is null.")).build(), multitask, maxProgression);
     }
 
     /**

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ main: com.fren_gor.ultimateAdvancementAPI.AdvancementPlugin
 name: UltimateAdvancementAPI
 version: ${apiVersion}
 description: ${project.description}
-author: [fren_gor, EscanorTargaryen]
+authors: [fren_gor, EscanorTargaryen]
 website: ${project.url}
 
 api-version: 1.15


### PR DESCRIPTION
This PR adds builders for `AdvancementDisplay` and `FancyAdvancementDisplay`.
Required options are specified in the constructors, everything else can be configured via builder.
Example usage:
```java
AdvancementDisplay rootDisplay =
   new AdvancementDisplay.Builder(Material.LAVA_BUCKET, "Lava", 0F, 0F, "This is lava", "And it's hot").build();

FancyAdvancementDisplay fancyDisplay =
   new FancyAdvancementDisplay.Builder(Material.WATER_BUCKET, "Water", 1F, 1F).offset(rootDisplay)
         .description("Water", "Good")
         .descriptionColor(ChatColor.AQUA)
         .announceAll()
         .build();

AdvancementDisplay thirdDisplay =
   new AdvancementDisplay.Builder(Material.MILK_BUCKET, "MInk", 2F, 1F).offset(fancyDisplay).goalFrame().build();
```
Also introduces `offset()` method which makes coordinates calculations easier.