### PR TITLE
Update to 2.2.5

### DIFF
--- a/Commands/CommandAPI-9.0.3/pom.xml
+++ b/Commands/CommandAPI-9.0.3/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9-0-3</artifactId>
     <name>UltimateAdvancementAPI-Commands-CommandAPI-9-0-3</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/CommandAPI-9.0.3/pom.xml
+++ b/Commands/CommandAPI-9.0.3/pom.xml
@@ -10,8 +10,8 @@
         <version>parent-SNAPSHOT</version>
     </parent>
 
-    <artifactId>ultimateadvancementapi-commands-commandapi-9-0-2</artifactId>
-    <name>UltimateAdvancementAPI-Commands-CommandAPI-9-0-2</name>
+    <artifactId>ultimateadvancementapi-commands-commandapi-9-0-3</artifactId>
+    <name>UltimateAdvancementAPI-Commands-CommandAPI-9-0-3</name>
     <version>2.2.4</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-bukkit-shade</artifactId>
-            <version>9.0.2</version>
+            <version>9.0.3</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/AdvancementArgument.java
+++ b/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/AdvancementArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_2;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_3;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;

--- a/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/AdvancementTabArgument.java
+++ b/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/AdvancementTabArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_2;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_3;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;

--- a/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/CommandAPIManager.java
+++ b/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/CommandAPIManager.java
@@ -1,10 +1,9 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_2;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_3;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIBukkitConfig;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 

--- a/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-9.0.3/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_0_3/UltimateAdvancementAPICommand.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_2;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_3;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
@@ -6,7 +6,6 @@ import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.BooleanArgument;
-import dev.jorel.commandapi.arguments.CommandArgument;
 import dev.jorel.commandapi.arguments.EntitySelectorArgument;
 import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException;
@@ -21,8 +20,8 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_2.AdvancementArgument.getAdvancementArgument;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_2.AdvancementTabArgument.getAdvancementTabArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_3.AdvancementArgument.getAdvancementArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_0_3.AdvancementTabArgument.getAdvancementTabArgument;
 
 public class UltimateAdvancementAPICommand {
 

--- a/Commands/Common/pom.xml
+++ b/Commands/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-common</artifactId>
     <name>UltimateAdvancementAPI-Commands-Common</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
@@ -11,7 +11,7 @@ import java.util.List;
  * Enum containing the used versions of <a href="https://github.com/JorelAli/CommandAPI">CommandAPI</a>.
  */
 public enum CommandAPIVersion {
-    LATEST("9.0.2", "YWLWhaRNTRMMeTopmYfpq+Df05+beX6TgylTG56gN1c=", "9_0_2", List.of(
+    LATEST("9.0.3", "uJzcFNNX8Y0U9xiaqBW43WQNcJrhARJpwydVN15GG3k=", "9_0_3", List.of(
             "v1_15_R1",
             "v1_16_R1",
             "v1_16_R2",

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-distribution</artifactId>
     <name>UltimateAdvancementAPI-Commands-Distribution</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
     

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -25,7 +25,7 @@
         <!-- Command Modules -->
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-9-0-2</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-9-0-3</artifactId>
             <version>${apiVersion}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -22,7 +22,7 @@
 
     <modules>
         <module>Common</module>
-        <module>CommandAPI-9.0.2</module>
+        <module>CommandAPI-9.0.3</module>
         <module>Distribution</module>
     </modules>
 

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-common</artifactId>
     <name>UltimateAdvancementAPI-Common</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -30,7 +30,7 @@ public class Versions {
             Map.entry("v1_19_R1", List.of("1.19", "1.19.2")),
             Map.entry("v1_19_R2", List.of("1.19.3")),
             Map.entry("v1_19_R3", List.of("1.19.4")),
-            Map.entry("v1_20_R1", List.of("1.20"))
+            Map.entry("v1_20_R1", List.of("1.20", "1.20.1"))
     );
 
     private static final Map<String, String> NMS_TO_FANCY = Map.ofEntries(
@@ -44,7 +44,7 @@ public class Versions {
             Map.entry("v1_19_R1", "1.19-1.19.2"),
             Map.entry("v1_19_R2", "1.19.3"),
             Map.entry("v1_19_R3", "1.19.4"),
-            Map.entry("v1_20_R1", "1.20")
+            Map.entry("v1_20_R1", "1.20-1.20.1")
     );
 
     private static final List<String> SUPPORTED_VERSIONS = SUPPORTED_NMS_VERSIONS.stream()

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  */
 public class Versions {
 
-    private static final String API_VERSION = "2.2.4";
+    private static final String API_VERSION = "2.2.5";
 
     private static final List<String> SUPPORTED_NMS_VERSIONS = List.of("v1_15_R1", "v1_16_R1", "v1_16_R2", "v1_16_R3", "v1_17_R1", "v1_18_R1", "v1_18_R2", "v1_19_R1", "v1_19_R2", "v1_19_R3", "v1_20_R1");
 

--- a/Distribution/API/pom.xml
+++ b/Distribution/API/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi</artifactId>
     <name>UltimateAdvancementAPI</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Distribution/Commands/pom.xml
+++ b/Distribution/Commands/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands</artifactId>
     <name>UltimateAdvancementAPI-Commands</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Distribution/Shadeable/pom.xml
+++ b/Distribution/Shadeable/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-shadeable</artifactId>
     <name>UltimateAdvancementAPI-Shadeable</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_15_R1/pom.xml
+++ b/NMS/1_15_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_15_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_15_R1</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R1/pom.xml
+++ b/NMS/1_16_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R1</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R2/pom.xml
+++ b/NMS/1_16_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R2</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R3/pom.xml
+++ b/NMS/1_16_R3/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R3</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R3</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_17_R1/pom.xml
+++ b/NMS/1_17_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_17_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_17_R1</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_18_R1/pom.xml
+++ b/NMS/1_18_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_18_R1</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_18_R2/pom.xml
+++ b/NMS/1_18_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_18_R2</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_19_R1/pom.xml
+++ b/NMS/1_19_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_19_R1</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_19_R2/pom.xml
+++ b/NMS/1_19_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_19_R2</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_19_R3/pom.xml
+++ b/NMS/1_19_R3/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_19_R3</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_20_R1/pom.xml
+++ b/NMS/1_20_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_20_R1</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_20_R1/pom.xml
+++ b/NMS/1_20_R1/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <classifier>remapped-mojang</classifier>
         </dependency>
@@ -60,9 +60,9 @@
                             <goal>remap</goal>
                         </goals>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.20-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.20.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.20-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.20.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -75,8 +75,8 @@
                         </goals>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.20-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.20-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.20.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.20.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-common</artifactId>
     <name>UltimateAdvancementAPI-NMS-Common</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-distribution</artifactId>
     <name>UltimateAdvancementAPI-NMS-Distribution</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>
     <name>UltimateAdvancementAPI-Plugin</name>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementPlugin.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementPlugin.java
@@ -54,8 +54,15 @@ public class AdvancementPlugin extends JavaPlugin {
         }
 
         commandAPIManager = CommandAPIManager.loadManager(main.getLibbyManager());
-        if (commandAPIManager != null) // In case commands couldn't be loaded
-            commandAPIManager.onLoad(main, this);
+        if (commandAPIManager != null) { // In case commands couldn't be loaded
+            try {
+                commandAPIManager.onLoad(main, this);
+            } catch (Exception e) {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[UltimateAdvancementAPI] An exception occurred while loading commands for UltimateAdvancementAPI, continuing without them:");
+                e.printStackTrace();
+                commandAPIManager = null;
+            }
+        }
     }
 
     @Override
@@ -75,15 +82,20 @@ public class AdvancementPlugin extends JavaPlugin {
         try {
             configManager.enable(main);
         } catch (RuntimeException e) {
-            Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "An exception occurred while enabling UltimateAdvancementAPI:");
+            Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[UltimateAdvancementAPI] An exception occurred while enabling UltimateAdvancementAPI:");
             e.printStackTrace();
             // main.disable() is already called by AdvancementMain#failEnable(Exception)
             return;
         }
 
-        if (commandAPIManager != null) {// In case commands couldn't be loaded
-            commandAPIManager.onEnable();
-            commandsEnabled = true;
+        if (commandAPIManager != null) { // In case commands couldn't be loaded
+            try {
+                commandAPIManager.onEnable();
+                commandsEnabled = true;
+            } catch (Exception e) {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[UltimateAdvancementAPI] An exception occurred while enabling commands for UltimateAdvancementAPI, continuing without them:");
+                e.printStackTrace();
+            }
         }
 
         if (configManager.getDisableVanillaAdvancements()) {
@@ -93,7 +105,7 @@ public class AdvancementPlugin extends JavaPlugin {
                     try {
                         AdvancementUtils.disableVanillaAdvancements();
                     } catch (Exception e) {
-                        Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "Couldn't disable vanilla advancements:");
+                        Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[UltimateAdvancementAPI] Couldn't disable vanilla advancements:");
                         e.printStackTrace();
                     }
                 }
@@ -109,8 +121,9 @@ public class AdvancementPlugin extends JavaPlugin {
         if (!correctVersion) {
             return;
         }
-        if (commandAPIManager != null && commandsEnabled) // In case commands are not loaded/enabled
+        if (commandAPIManager != null && commandsEnabled) { // In case commands are not loaded/enabled
             commandAPIManager.onDisable();
+        }
         main.disable();
         main = null;
     }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A powerful API to create custom advancements for your minecraft server.
 <dependency>
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <!-- Project Properties -->
-        <apiVersion>2.2.4</apiVersion> <!-- Change also in Versions class -->
+        <apiVersion>2.2.5</apiVersion> <!-- Change also in Versions class -->
         <libbyVersion>1.1.5</libbyVersion>
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <optional>true</optional> <!-- Don't use latest api into per-version code -->
         </dependency>


### PR DESCRIPTION
Update version to 2.2.5
Update to Minecraft 1.20.1
Update CommandAPI to 9.0.3 by @dandan2611
The plugin version of the API now doesn't crash anymore when it fails to load or enable commands