### PR TITLE
Update to 2.2.7

### DIFF
--- a/Commands/CommandAPI-9.2.0/pom.xml
+++ b/Commands/CommandAPI-9.2.0/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9-2-0</artifactId>
     <name>UltimateAdvancementAPI-Commands-CommandAPI-9-2-0</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/Common/pom.xml
+++ b/Commands/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-common</artifactId>
     <name>UltimateAdvancementAPI-Commands-Common</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands-distribution</artifactId>
     <name>UltimateAdvancementAPI-Commands-Distribution</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
     

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-common</artifactId>
     <name>UltimateAdvancementAPI-Common</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/PlayerLoadingCompletedEvent.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/PlayerLoadingCompletedEvent.java
@@ -4,6 +4,7 @@ import com.fren_gor.ultimateAdvancementAPI.database.TeamProgression;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -12,6 +13,7 @@ import static com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils.validate
 
 /**
  * Called when a player is loaded successfully.
+ * <p>Will always be called after the {@link PlayerJoinEvent} for such player.
  */
 public final class PlayerLoadingCompletedEvent extends Event {
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/PlayerLoadingFailedEvent.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/events/PlayerLoadingFailedEvent.java
@@ -3,6 +3,7 @@ package com.fren_gor.ultimateAdvancementAPI.events;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,6 +11,7 @@ import java.util.Objects;
 
 /**
  * Called when a player loading fails.
+ * <p>Will always be called after the {@link PlayerJoinEvent} for such player.
  */
 public final class PlayerLoadingFailedEvent extends Event {
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  */
 public class Versions {
 
-    private static final String API_VERSION = "2.2.6";
+    private static final String API_VERSION = "2.2.7";
 
     private static final List<String> SUPPORTED_NMS_VERSIONS = List.of(
             "v1_15_R1",

--- a/Distribution/API/pom.xml
+++ b/Distribution/API/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi</artifactId>
     <name>UltimateAdvancementAPI</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Distribution/Commands/pom.xml
+++ b/Distribution/Commands/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-commands</artifactId>
     <name>UltimateAdvancementAPI-Commands</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Distribution/Shadeable/pom.xml
+++ b/Distribution/Shadeable/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-shadeable</artifactId>
     <name>UltimateAdvancementAPI-Shadeable</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_15_R1/pom.xml
+++ b/NMS/1_15_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_15_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_15_R1</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R1/pom.xml
+++ b/NMS/1_16_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R1</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R2/pom.xml
+++ b/NMS/1_16_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R2</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_16_R3/pom.xml
+++ b/NMS/1_16_R3/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_16_R3</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_16_R3</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_17_R1/pom.xml
+++ b/NMS/1_17_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_17_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_17_R1</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_18_R1/pom.xml
+++ b/NMS/1_18_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_18_R1</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_18_R2/pom.xml
+++ b/NMS/1_18_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_18_R2</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_19_R1/pom.xml
+++ b/NMS/1_19_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_19_R1</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_19_R2/pom.xml
+++ b/NMS/1_19_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_19_R2</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_19_R3/pom.xml
+++ b/NMS/1_19_R3/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_19_R3</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_20_R1/pom.xml
+++ b/NMS/1_20_R1/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_20_R1</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/1_20_R2/pom.xml
+++ b/NMS/1_20_R2/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-1_20_R2</artifactId>
     <name>UltimateAdvancementAPI-NMS-1_20_R2</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-common</artifactId>
     <name>UltimateAdvancementAPI-NMS-Common</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-nms-distribution</artifactId>
     <name>UltimateAdvancementAPI-NMS-Distribution</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>
     <name>UltimateAdvancementAPI-Plugin</name>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A powerful API to create custom advancements for your minecraft server.
 <dependency>
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <!-- Project Properties -->
-        <apiVersion>2.2.6</apiVersion> <!-- Change also in Versions class -->
+        <apiVersion>2.2.7</apiVersion> <!-- Change also in Versions class -->
         <libbyVersion>1.1.5</libbyVersion>
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <optional>true</optional> <!-- Don't use latest api into per-version code -->
         </dependency>


### PR DESCRIPTION
* Update version to 2.2.7
* Fix `NullPointerException` on player join on 1.20.2
* Now `PlayerLoadingCompletedEvent` and `PlayerLoadingFailedEvent` are always called after `PlayerJoinEvent`