### PR TITLE
allow json serialized components for advancement displays

### DIFF
--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/display/FancyAdvancementDisplay.java
@@ -1,9 +1,7 @@
 package com.fren_gor.ultimateAdvancementAPI.advancement.display;
 
-import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
 import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -152,13 +150,8 @@ public class FancyAdvancementDisplay extends AdvancementDisplay {
         super(icon, title, frame, showToast, announceChat, x, y, defaultDescriptionColor, description);
         Preconditions.checkNotNull(defaultTitleColor, "Default title color is null.");
 
-        this.chatTitle[0] = new TextComponent(defaultTitleColor + rawTitle);
-
-        if (compactDescription.isEmpty()) {
-            this.chatDescription[0] = new TextComponent(defaultTitleColor + rawTitle);
-        } else {
-            this.chatDescription[0] = new TextComponent(defaultTitleColor + rawTitle + (AdvancementUtils.startsWithEmptyLine(compactDescription) ? "\n" : "\n\n") + compactDescription);
-        }
+        this.chatTitle[0] = fromString(title, defaultTitleColor);
+        this.chatDescription[0] = fromStringList(this.chatTitle[0], description, defaultDescriptionColor);
     }
 
     /**

--- a/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/Util.java
+++ b/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/Util.java
@@ -8,6 +8,7 @@ import net.minecraft.server.v1_15_R1.Criterion;
 import net.minecraft.server.v1_15_R1.CriterionProgress;
 import net.minecraft.server.v1_15_R1.CriterionTriggerImpossible;
 import net.minecraft.server.v1_15_R1.IChatBaseComponent;
+import net.minecraft.server.v1_15_R1.IChatBaseComponent.ChatSerializer;
 import net.minecraft.server.v1_15_R1.Packet;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.util.CraftChatMessage;
@@ -75,7 +76,8 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        var component = ChatSerializer.a(string);
+        return component != null ? component : CraftChatMessage.fromStringOrNull(string, true);
     }
 
     private Util() {

--- a/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/Util.java
+++ b/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/Util.java
@@ -8,6 +8,7 @@ import net.minecraft.server.v1_16_R1.Criterion;
 import net.minecraft.server.v1_16_R1.CriterionProgress;
 import net.minecraft.server.v1_16_R1.CriterionTriggerImpossible;
 import net.minecraft.server.v1_16_R1.IChatBaseComponent;
+import net.minecraft.server.v1_16_R1.IChatBaseComponent.ChatSerializer;
 import net.minecraft.server.v1_16_R1.Packet;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.util.CraftChatMessage;
@@ -67,7 +68,8 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return ChatComponentText.d;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        var component = ChatSerializer.a(string);
+        return component != null ? component : CraftChatMessage.fromStringOrNull(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/Util.java
+++ b/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/Util.java
@@ -8,6 +8,7 @@ import net.minecraft.server.v1_16_R2.Criterion;
 import net.minecraft.server.v1_16_R2.CriterionProgress;
 import net.minecraft.server.v1_16_R2.CriterionTriggerImpossible;
 import net.minecraft.server.v1_16_R2.IChatBaseComponent;
+import net.minecraft.server.v1_16_R2.IChatBaseComponent.ChatSerializer;
 import net.minecraft.server.v1_16_R2.Packet;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.util.CraftChatMessage;
@@ -67,7 +68,8 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return ChatComponentText.d;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        var component = ChatSerializer.a(string);
+        return component != null ? component : CraftChatMessage.fromStringOrNull(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/Util.java
+++ b/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/Util.java
@@ -67,7 +67,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return ChatComponentText.d;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/Util.java
+++ b/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return TextComponent.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/Util.java
+++ b/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return TextComponent.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_18_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R2/Util.java
+++ b/NMS/1_18_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R2/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return TextComponent.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_19_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R1/Util.java
+++ b/NMS/1_19_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R1/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
 

--- a/NMS/1_19_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R2/Util.java
+++ b/NMS/1_19_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R2/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_19_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R3/Util.java
+++ b/NMS/1_19_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R3/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_20_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R1/Util.java
+++ b/NMS/1_20_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R1/Util.java
@@ -68,7 +68,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_20_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R2/Util.java
+++ b/NMS/1_20_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R2/Util.java
@@ -70,7 +70,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/Util.java
+++ b/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/Util.java
@@ -71,7 +71,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/advancement/AdvancementDisplayWrapper_v1_20_R3.java
+++ b/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/advancement/AdvancementDisplayWrapper_v1_20_R3.java
@@ -1,11 +1,10 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_20_R3.advancement;
 
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_20_R3.Util;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
 import net.minecraft.advancements.DisplayInfo;
 import net.minecraft.advancements.AdvancementType;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.contents.PlainTextContents.LiteralContents;
 import net.minecraft.resources.ResourceLocation;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftChatMessage;
@@ -22,7 +21,7 @@ public class AdvancementDisplayWrapper_v1_20_R3 extends AdvancementDisplayWrappe
 
     public AdvancementDisplayWrapper_v1_20_R3(@NotNull ItemStack icon, @NotNull String title, @NotNull String description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
         ResourceLocation background = backgroundTexture == null ? null : new ResourceLocation(backgroundTexture);
-        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Component.literal(title), Component.literal(description), Optional.ofNullable(background), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Util.fromString(title), Util.fromString(description), Optional.ofNullable(background), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
         this.display.setLocation(x, y);
         this.frameType = frameType;
     }

--- a/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/Util.java
+++ b/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/Util.java
@@ -71,7 +71,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/advancement/AdvancementDisplayWrapper_v1_20_R4.java
+++ b/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/advancement/AdvancementDisplayWrapper_v1_20_R4.java
@@ -1,10 +1,10 @@
 package com.fren_gor.ultimateAdvancementAPI.nms.v1_20_R4.advancement;
 
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_20_R4.Util;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
 import net.minecraft.advancements.AdvancementType;
 import net.minecraft.advancements.DisplayInfo;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftChatMessage;
@@ -21,7 +21,7 @@ public class AdvancementDisplayWrapper_v1_20_R4 extends AdvancementDisplayWrappe
 
     public AdvancementDisplayWrapper_v1_20_R4(@NotNull ItemStack icon, @NotNull String title, @NotNull String description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
         ResourceLocation background = backgroundTexture == null ? null : new ResourceLocation(backgroundTexture);
-        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Component.literal(title), Component.literal(description), Optional.ofNullable(background), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Util.fromString(title), Util.fromString(description), Optional.ofNullable(background), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
         this.display.setLocation(x, y);
         this.frameType = frameType;
     }

--- a/NMS/1_21_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R1/Util.java
+++ b/NMS/1_21_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R1/Util.java
@@ -71,7 +71,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {

--- a/NMS/1_21_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R2/Util.java
+++ b/NMS/1_21_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R2/Util.java
@@ -71,7 +71,7 @@ public class Util {
         if (string == null || string.isEmpty()) {
             return CommonComponents.EMPTY;
         }
-        return CraftChatMessage.fromStringOrNull(string, true);
+        return CraftChatMessage.fromJSONOrString(string, true, true);
     }
 
     public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {


### PR DESCRIPTION
This PR switches to CraftChatMessage.fromJSONOrString for parsing the advancment display title/description to allow usage of json serialized components.
For example this would be a valid title: `{"extra":[{"color":"dark_aqua","text":"Adapt"},"\n",{"color":"#1C6A73","translate":"item.minecraft.diamond"}],"text":""}`