### PR TITLE
Make vanilla recipes advancement available while disabling the other vanilla advancements.

### DIFF
--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
@@ -256,6 +256,16 @@ public final class UltimateAdvancementAPI {
 
     /**
      * Disables the vanilla advancements until next server restart or reload.
+     * Disable vanilla recipes advancements too.
+     * 
+     * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
+     */
+    public void disableVanillaAdvancements() throws RuntimeException {
+        disableVanillaAdvancements(true);
+    }
+
+    /**
+     * Disables the vanilla advancements until next server restart or reload.
      *
      * @param disableVanillaRecipeAdvancements Disable vanilla recipes advancements.
      * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
@@ -266,15 +276,6 @@ public final class UltimateAdvancementAPI {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't disable minecraft advancements.", e);
         }
-    }
-    /**
-     * Disables the vanilla advancements until next server restart or reload.
-     * Disable vanilla recipes advancements too.
-     * 
-     * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
-     */
-    public void disableVanillaAdvancements() throws RuntimeException {
-        disableVanillaAdvancements(true);
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
@@ -259,9 +259,9 @@ public final class UltimateAdvancementAPI {
      *
      * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
      */
-    public void disableVanillaAdvancements() throws RuntimeException {
+    public void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws RuntimeException {
         try {
-            AdvancementUtils.disableVanillaAdvancements();
+            AdvancementUtils.disableVanillaAdvancements(disableVanillaAdvancementsRecipes);
         } catch (Exception e) {
             throw new RuntimeException("Couldn't disable minecraft advancements.", e);
         }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
@@ -257,6 +257,7 @@ public final class UltimateAdvancementAPI {
     /**
      * Disables the vanilla advancements until next server restart or reload.
      *
+     * @param disableVanillaAdvancementsRecipes Disable vanilla recipes advancements.
      * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
      */
     public void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws RuntimeException {
@@ -265,6 +266,15 @@ public final class UltimateAdvancementAPI {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't disable minecraft advancements.", e);
         }
+    }
+    /**
+     * Disables the vanilla advancements until next server restart or reload.
+     * Disable vanilla recipes advancements too.
+     * 
+     * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
+     */
+    public void disableVanillaAdvancements() throws RuntimeException {
+        disableVanillaAdvancements(true);
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/UltimateAdvancementAPI.java
@@ -257,12 +257,12 @@ public final class UltimateAdvancementAPI {
     /**
      * Disables the vanilla advancements until next server restart or reload.
      *
-     * @param disableVanillaAdvancementsRecipes Disable vanilla recipes advancements.
+     * @param disableVanillaRecipeAdvancements Disable vanilla recipes advancements.
      * @throws RuntimeException If the operation fails. It is a wrapper for the real exception.
      */
-    public void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws RuntimeException {
+    public void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws RuntimeException {
         try {
-            AdvancementUtils.disableVanillaAdvancements(disableVanillaAdvancementsRecipes);
+            AdvancementUtils.disableVanillaAdvancements(disableVanillaRecipeAdvancements);
         } catch (Exception e) {
             throw new RuntimeException("Couldn't disable minecraft advancements.", e);
         }

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -141,7 +141,7 @@ public class AdvancementUtils {
      * @throws Exception If disabling goes wrong.
      * @see UltimateAdvancementAPI#disableVanillaAdvancements()
      */
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         VanillaAdvancementDisablerWrapper.disableVanillaAdvancements();
     }
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -138,12 +138,12 @@ public class AdvancementUtils {
     /**
      * Disable vanilla advancement.
      *
-     * @param disableVanillaAdvancementsRecipes Disable vanilla recipes advancements.
+     * @param disableVanillaRecipeAdvancements Disable vanilla recipes advancements.
      * @throws Exception If disabling goes wrong.
      * @see UltimateAdvancementAPI#disableVanillaAdvancements(boolean)
      */
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
-        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(disableVanillaAdvancementsRecipes);
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
+        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(disableVanillaRecipeAdvancements);
     }
 
     /**

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -137,17 +137,6 @@ public class AdvancementUtils {
 
     /**
      * Disable vanilla advancement.
-     *
-     * @param disableVanillaRecipeAdvancements Disable vanilla recipes advancements.
-     * @throws Exception If disabling goes wrong.
-     * @see UltimateAdvancementAPI#disableVanillaAdvancements(boolean)
-     */
-    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
-        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(disableVanillaRecipeAdvancements);
-    }
-
-    /**
-     * Disable vanilla advancement.
      * Disable vanilla recipes advancements too.
      * 
      * @throws Exception If disabling goes wrong.
@@ -155,6 +144,17 @@ public class AdvancementUtils {
      */
     public static void disableVanillaAdvancements() throws Exception {
         VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(true);
+    }
+
+    /**
+     * Disable vanilla advancement.
+     *
+     * @param disableVanillaRecipeAdvancements Disable vanilla recipes advancements.
+     * @throws Exception If disabling goes wrong.
+     * @see UltimateAdvancementAPI#disableVanillaAdvancements(boolean)
+     */
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
+        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(disableVanillaRecipeAdvancements);
     }
 
     @NotNull

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -139,10 +139,10 @@ public class AdvancementUtils {
      * Disable vanilla advancement.
      *
      * @throws Exception If disabling goes wrong.
-     * @see UltimateAdvancementAPI#disableVanillaAdvancements()
+     * @see UltimateAdvancementAPI#disableVanillaAdvancements(boolean)
      */
     public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
-        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements();
+        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(disableVanillaAdvancementsRecipes);
     }
 
     @NotNull

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -138,11 +138,23 @@ public class AdvancementUtils {
     /**
      * Disable vanilla advancement.
      *
+     * @param disableVanillaAdvancementsRecipes Disable vanilla recipes advancements.
      * @throws Exception If disabling goes wrong.
      * @see UltimateAdvancementAPI#disableVanillaAdvancements(boolean)
      */
     public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(disableVanillaAdvancementsRecipes);
+    }
+
+    /**
+     * Disable vanilla advancement.
+     * Disable vanilla recipes advancements too.
+     * 
+     * @throws Exception If disabling goes wrong.
+     * @see UltimateAdvancementAPI#disableVanillaAdvancements(boolean)
+     */
+    public static void disableVanillaAdvancements() throws Exception {
+        VanillaAdvancementDisablerWrapper.disableVanillaAdvancements(true);
     }
 
     @NotNull

--- a/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/VanillaAdvancementDisablerWrapper_v1_15_R1.java
+++ b/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/VanillaAdvancementDisablerWrapper_v1_15_R1.java
@@ -44,7 +44,7 @@ public class VanillaAdvancementDisablerWrapper_v1_15_R1 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         Advancements registry = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData().REGISTRY;
 
         if (registry.advancements.isEmpty()) {

--- a/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/VanillaAdvancementDisablerWrapper_v1_15_R1.java
+++ b/NMS/1_15_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_15_R1/VanillaAdvancementDisablerWrapper_v1_15_R1.java
@@ -44,7 +44,7 @@ public class VanillaAdvancementDisablerWrapper_v1_15_R1 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         Advancements registry = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData().REGISTRY;
 
         if (registry.advancements.isEmpty()) {

--- a/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/VanillaAdvancementDisablerWrapper_v1_16_R1.java
+++ b/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/VanillaAdvancementDisablerWrapper_v1_16_R1.java
@@ -45,7 +45,7 @@ public class VanillaAdvancementDisablerWrapper_v1_16_R1 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         AdvancementDataWorld serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData();
         Advancements registry = serverAdvancements.REGISTRY;
 

--- a/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/VanillaAdvancementDisablerWrapper_v1_16_R1.java
+++ b/NMS/1_16_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R1/VanillaAdvancementDisablerWrapper_v1_16_R1.java
@@ -45,7 +45,7 @@ public class VanillaAdvancementDisablerWrapper_v1_16_R1 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         AdvancementDataWorld serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData();
         Advancements registry = serverAdvancements.REGISTRY;
 

--- a/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/VanillaAdvancementDisablerWrapper_v1_16_R2.java
+++ b/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/VanillaAdvancementDisablerWrapper_v1_16_R2.java
@@ -45,7 +45,7 @@ public class VanillaAdvancementDisablerWrapper_v1_16_R2 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         AdvancementDataWorld serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData();
         Advancements registry = serverAdvancements.REGISTRY;
 

--- a/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/VanillaAdvancementDisablerWrapper_v1_16_R2.java
+++ b/NMS/1_16_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R2/VanillaAdvancementDisablerWrapper_v1_16_R2.java
@@ -45,7 +45,7 @@ public class VanillaAdvancementDisablerWrapper_v1_16_R2 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         AdvancementDataWorld serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData();
         Advancements registry = serverAdvancements.REGISTRY;
 

--- a/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/VanillaAdvancementDisablerWrapper_v1_16_R3.java
+++ b/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/VanillaAdvancementDisablerWrapper_v1_16_R3.java
@@ -45,7 +45,7 @@ public class VanillaAdvancementDisablerWrapper_v1_16_R3 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         AdvancementDataWorld serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData();
         Advancements registry = serverAdvancements.REGISTRY;
 

--- a/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/VanillaAdvancementDisablerWrapper_v1_16_R3.java
+++ b/NMS/1_16_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_16_R3/VanillaAdvancementDisablerWrapper_v1_16_R3.java
@@ -45,7 +45,7 @@ public class VanillaAdvancementDisablerWrapper_v1_16_R3 extends VanillaAdvanceme
     }
 
     @SuppressWarnings("unchecked")
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         AdvancementDataWorld serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancementData();
         Advancements registry = serverAdvancements.REGISTRY;
 

--- a/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/VanillaAdvancementDisablerWrapper_v1_17_R1.java
+++ b/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/VanillaAdvancementDisablerWrapper_v1_17_R1.java
@@ -50,7 +50,7 @@ public class VanillaAdvancementDisablerWrapper_v1_17_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/VanillaAdvancementDisablerWrapper_v1_17_R1.java
+++ b/NMS/1_17_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_17_R1/VanillaAdvancementDisablerWrapper_v1_17_R1.java
@@ -50,7 +50,7 @@ public class VanillaAdvancementDisablerWrapper_v1_17_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/VanillaAdvancementDisablerWrapper_v1_18_R1.java
+++ b/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/VanillaAdvancementDisablerWrapper_v1_18_R1.java
@@ -50,7 +50,7 @@ public class VanillaAdvancementDisablerWrapper_v1_18_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/VanillaAdvancementDisablerWrapper_v1_18_R1.java
+++ b/NMS/1_18_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R1/VanillaAdvancementDisablerWrapper_v1_18_R1.java
@@ -50,7 +50,7 @@ public class VanillaAdvancementDisablerWrapper_v1_18_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_18_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R2/VanillaAdvancementDisablerWrapper_v1_18_R2.java
+++ b/NMS/1_18_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R2/VanillaAdvancementDisablerWrapper_v1_18_R2.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_18_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_18_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R2/VanillaAdvancementDisablerWrapper_v1_18_R2.java
+++ b/NMS/1_18_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_18_R2/VanillaAdvancementDisablerWrapper_v1_18_R2.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_18_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_19_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R1/VanillaAdvancementDisablerWrapper_v1_19_R1.java
+++ b/NMS/1_19_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R1/VanillaAdvancementDisablerWrapper_v1_19_R1.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_19_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_19_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R1/VanillaAdvancementDisablerWrapper_v1_19_R1.java
+++ b/NMS/1_19_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R1/VanillaAdvancementDisablerWrapper_v1_19_R1.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_19_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_19_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R2/VanillaAdvancementDisablerWrapper_v1_19_R2.java
+++ b/NMS/1_19_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R2/VanillaAdvancementDisablerWrapper_v1_19_R2.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_19_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_19_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R2/VanillaAdvancementDisablerWrapper_v1_19_R2.java
+++ b/NMS/1_19_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R2/VanillaAdvancementDisablerWrapper_v1_19_R2.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_19_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_19_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R3/VanillaAdvancementDisablerWrapper_v1_19_R3.java
+++ b/NMS/1_19_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R3/VanillaAdvancementDisablerWrapper_v1_19_R3.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_19_R3 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_19_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R3/VanillaAdvancementDisablerWrapper_v1_19_R3.java
+++ b/NMS/1_19_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_19_R3/VanillaAdvancementDisablerWrapper_v1_19_R3.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_19_R3 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_20_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R1/VanillaAdvancementDisablerWrapper_v1_20_R1.java
+++ b/NMS/1_20_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R1/VanillaAdvancementDisablerWrapper_v1_20_R1.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_20_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R1/VanillaAdvancementDisablerWrapper_v1_20_R1.java
+++ b/NMS/1_20_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R1/VanillaAdvancementDisablerWrapper_v1_20_R1.java
@@ -63,7 +63,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementList registry = serverAdvancements.advancements;
 

--- a/NMS/1_20_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R2/VanillaAdvancementDisablerWrapper_v1_20_R2.java
+++ b/NMS/1_20_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R2/VanillaAdvancementDisablerWrapper_v1_20_R2.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R2 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft")) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_20_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R2/VanillaAdvancementDisablerWrapper_v1_20_R2.java
+++ b/NMS/1_20_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R2/VanillaAdvancementDisablerWrapper_v1_20_R2.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R2 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaRecipeAdvancements || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/VanillaAdvancementDisablerWrapper_v1_20_R3.java
+++ b/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/VanillaAdvancementDisablerWrapper_v1_20_R3.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R3 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R3 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft")) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/VanillaAdvancementDisablerWrapper_v1_20_R3.java
+++ b/NMS/1_20_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R3/VanillaAdvancementDisablerWrapper_v1_20_R3.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R3 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R3 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaRecipeAdvancements || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/VanillaAdvancementDisablerWrapper_v1_20_R4.java
+++ b/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/VanillaAdvancementDisablerWrapper_v1_20_R4.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R4 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R4 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft")) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/VanillaAdvancementDisablerWrapper_v1_20_R4.java
+++ b/NMS/1_20_R4/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_20_R4/VanillaAdvancementDisablerWrapper_v1_20_R4.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R4 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_20_R4 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaRecipeAdvancements || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_21_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R1/VanillaAdvancementDisablerWrapper_v1_21_R1.java
+++ b/NMS/1_21_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R1/VanillaAdvancementDisablerWrapper_v1_21_R1.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R1 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft")) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_21_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R1/VanillaAdvancementDisablerWrapper_v1_21_R1.java
+++ b/NMS/1_21_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R1/VanillaAdvancementDisablerWrapper_v1_21_R1.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R1 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R1 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaRecipeAdvancements || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_21_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R2/VanillaAdvancementDisablerWrapper_v1_21_R2.java
+++ b/NMS/1_21_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R2/VanillaAdvancementDisablerWrapper_v1_21_R2.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R2 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft")) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_21_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R2/VanillaAdvancementDisablerWrapper_v1_21_R2.java
+++ b/NMS/1_21_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R2/VanillaAdvancementDisablerWrapper_v1_21_R2.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R2 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R2 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaRecipeAdvancements || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_21_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R3/VanillaAdvancementDisablerWrapper_v1_21_R3.java
+++ b/NMS/1_21_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R3/VanillaAdvancementDisablerWrapper_v1_21_R3.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R3 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R3 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaRecipeAdvancements || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/1_21_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R3/VanillaAdvancementDisablerWrapper_v1_21_R3.java
+++ b/NMS/1_21_R3/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R3/VanillaAdvancementDisablerWrapper_v1_21_R3.java
@@ -65,7 +65,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R3 extends VanillaAdvanceme
         }
     }
 
-    public static void disableVanillaAdvancements() throws Exception {
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
         AdvancementTree tree = serverAdvancements.tree();
 
@@ -116,7 +116,7 @@ public class VanillaAdvancementDisablerWrapper_v1_21_R3 extends VanillaAdvanceme
             ImmutableMap.Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
             for (var entry : serverAdvancements.advancements.entrySet()) {
                 ResourceLocation key = entry.getKey();
-                if (key.getNamespace().equals("minecraft")) {
+                if (key.getNamespace().equals("minecraft") && (disableVanillaAdvancementsRecipes || !key.getPath().startsWith("recipes/"))) {
                     locations.add(key);
                 } else {
                     builder.put(key, entry.getValue());

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
@@ -28,11 +28,11 @@ public class VanillaAdvancementDisablerWrapper {
     /**
      * Disable vanilla advancement.
      *
-     * @param disableVanillaAdvancementsRecipes Disable vanilla recipes advancements.
+     * @param disableVanillaRecipeAdvancements Disable vanilla recipes advancements.
      * @throws Exception If disabling goes wrong.
      */
-    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
-        method.invoke(null, disableVanillaAdvancementsRecipes);
+    public static void disableVanillaAdvancements(boolean disableVanillaRecipeAdvancements) throws Exception {
+        method.invoke(null, disableVanillaRecipeAdvancements);
     }
 
     /**

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
@@ -17,9 +17,10 @@ public class VanillaAdvancementDisablerWrapper {
         var clazz = ReflectionUtil.getWrapperClass(VanillaAdvancementDisablerWrapper.class);
         assert clazz != null : "Wrapper class is null.";
         try {
-            method = clazz.getDeclaredMethod("disableVanillaAdvancements");
-            Preconditions.checkArgument(Modifier.isPublic(method.getModifiers()), "Method disableVanillaAdvancements() is not public.");
-            Preconditions.checkArgument(Modifier.isStatic(method.getModifiers()), "Method disableVanillaAdvancements() is not static.");
+            Class params[] = { boolean.class };
+            method = clazz.getDeclaredMethod("disableVanillaAdvancements", params);
+            Preconditions.checkArgument(Modifier.isPublic(method.getModifiers()), "Method disableVanillaAdvancements(boolean) is not public.");
+            Preconditions.checkArgument(Modifier.isStatic(method.getModifiers()), "Method disableVanillaAdvancements(boolean) is not static.");
         } catch (ReflectiveOperationException e) {
             e.printStackTrace();
         }
@@ -30,7 +31,7 @@ public class VanillaAdvancementDisablerWrapper {
      *
      * @throws Exception If disabling goes wrong.
      */
-    public static void disableVanillaAdvancements() throws Exception {
-        method.invoke(null);
+    public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
+        method.invoke(null, disableVanillaAdvancementsRecipes);
     }
 }

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
@@ -17,8 +17,7 @@ public class VanillaAdvancementDisablerWrapper {
         var clazz = ReflectionUtil.getWrapperClass(VanillaAdvancementDisablerWrapper.class);
         assert clazz != null : "Wrapper class is null.";
         try {
-            Class params[] = { boolean.class };
-            method = clazz.getDeclaredMethod("disableVanillaAdvancements", params);
+            method = clazz.getDeclaredMethod("disableVanillaAdvancements", boolean.class);
             Preconditions.checkArgument(Modifier.isPublic(method.getModifiers()), "Method disableVanillaAdvancements(boolean) is not public.");
             Preconditions.checkArgument(Modifier.isStatic(method.getModifiers()), "Method disableVanillaAdvancements(boolean) is not static.");
         } catch (ReflectiveOperationException e) {

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
@@ -28,7 +28,7 @@ public class VanillaAdvancementDisablerWrapper {
     /**
      * Disable vanilla advancement.
      *
-     * @param disableVanillaAdvancementsRecipes Disable vanilla advancement recipes.
+     * @param disableVanillaAdvancementsRecipes Disable vanilla recipes advancements.
      * @throws Exception If disabling goes wrong.
      */
     public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
@@ -37,10 +37,11 @@ public class VanillaAdvancementDisablerWrapper {
 
     /**
      * Disable vanilla advancement.
-     * It disable the recipes advancements too.
+     * Disable vanilla recipes advancements too.
+     * 
      * @throws Exception If disabling goes wrong.
      */
     public static void disableVanillaAdvancements() throws Exception {
-        disableVanillaAdvancements(disableVanillaAdvancementsRecipes, true);
+        disableVanillaAdvancements(true);
     }
 }

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/wrappers/VanillaAdvancementDisablerWrapper.java
@@ -29,9 +29,19 @@ public class VanillaAdvancementDisablerWrapper {
     /**
      * Disable vanilla advancement.
      *
+     * @param disableVanillaAdvancementsRecipes Disable vanilla advancement recipes.
      * @throws Exception If disabling goes wrong.
      */
     public static void disableVanillaAdvancements(boolean disableVanillaAdvancementsRecipes) throws Exception {
         method.invoke(null, disableVanillaAdvancementsRecipes);
+    }
+
+    /**
+     * Disable vanilla advancement.
+     * It disable the recipes advancements too.
+     * @throws Exception If disabling goes wrong.
+     */
+    public static void disableVanillaAdvancements() throws Exception {
+        disableVanillaAdvancements(disableVanillaAdvancementsRecipes, true);
     }
 }

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementPlugin.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/AdvancementPlugin.java
@@ -103,7 +103,7 @@ public class AdvancementPlugin extends JavaPlugin {
                 @Override
                 public void run() {
                     try {
-                        AdvancementUtils.disableVanillaAdvancements();
+                        AdvancementUtils.disableVanillaAdvancements(configManager.getDisableVanillaAdvancementsRecipes());
                     } catch (Exception e) {
                         Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[UltimateAdvancementAPI] Couldn't disable vanilla advancements:");
                         e.printStackTrace();

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
@@ -20,7 +20,7 @@ public class ConfigManager {
     private final YamlConfiguration config = new YamlConfiguration();
 
     private boolean disableVanillaAdvancements;
-    private boolean disableVanillaAdvancementsRecipes;
+    private boolean disableVanillaRecipeAdvancements;
     // db parameters
     private DB_TYPE storageType;
     private String sqlLiteDbName;
@@ -52,7 +52,7 @@ public class ConfigManager {
         }
 
         disableVanillaAdvancements = config.getBoolean("disable-vanilla-advancements");
-        disableVanillaAdvancementsRecipes = config.getBoolean("disable-vanilla-recipe-advancements");
+        disableVanillaRecipeAdvancements = config.getBoolean("disable-vanilla-recipe-advancements");
 
         String type = config.getString("storage-type");
         if (type == null) {
@@ -115,7 +115,7 @@ public class ConfigManager {
     }
 
     public boolean getDisableVanillaAdvancementsRecipes() {
-        return disableVanillaAdvancementsRecipes;
+        return disableVanillaRecipeAdvancements;
     }
 
     public DB_TYPE getStorageType() {

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
@@ -52,7 +52,7 @@ public class ConfigManager {
         }
 
         disableVanillaAdvancements = config.getBoolean("disable-vanilla-advancements");
-        disableVanillaAdvancementsRecipes = config.getBoolean("disable-vanilla-advancements-recipes");
+        disableVanillaAdvancementsRecipes = config.getBoolean("disable-vanilla-recipe-advancements");
 
         String type = config.getString("storage-type");
         if (type == null) {

--- a/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
+++ b/Plugin/src/main/java/com/fren_gor/ultimateAdvancementAPI/ConfigManager.java
@@ -20,6 +20,7 @@ public class ConfigManager {
     private final YamlConfiguration config = new YamlConfiguration();
 
     private boolean disableVanillaAdvancements;
+    private boolean disableVanillaAdvancementsRecipes;
     // db parameters
     private DB_TYPE storageType;
     private String sqlLiteDbName;
@@ -51,6 +52,7 @@ public class ConfigManager {
         }
 
         disableVanillaAdvancements = config.getBoolean("disable-vanilla-advancements");
+        disableVanillaAdvancementsRecipes = config.getBoolean("disable-vanilla-advancements-recipes");
 
         String type = config.getString("storage-type");
         if (type == null) {
@@ -110,6 +112,10 @@ public class ConfigManager {
 
     public boolean getDisableVanillaAdvancements() {
         return disableVanillaAdvancements;
+    }
+
+    public boolean getDisableVanillaAdvancementsRecipes() {
+        return disableVanillaAdvancementsRecipes;
     }
 
     public DB_TYPE getStorageType() {

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -5,6 +5,8 @@
 # NB: This will make players lose their progress on vanilla advancements (because their are being disabled).
 #     Also, a bunch of lines will print on the console every time a player joins. Just ignore them.
 disable-vanilla-advancements: false
+# If vanilla advancements are disable, do we also disable recipes. Most of the time, we don't. Works from version 1.20.2 to latest.
+disable-vanilla-advancements-recipes: false
 
 # Database settings
 #

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -36,4 +36,4 @@ mysql:
     connectionTimeout: 6000
 
 # Do not touch!!!
-config-version: 1
+config-version: 2

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -6,7 +6,7 @@
 #     Also, a bunch of lines will print on the console every time a player joins. Just ignore them.
 disable-vanilla-advancements: false
 # If vanilla advancements are disabled, whether to also disable advancements that unlock recipes. Works from version 1.20.2 to latest.
-disable-vanilla-advancements-recipes: false
+disable-vanilla-recipe-advancements: false
 
 # Database settings
 #

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -5,7 +5,7 @@
 # NB: This will make players lose their progress on vanilla advancements (because their are being disabled).
 #     Also, a bunch of lines will print on the console every time a player joins. Just ignore them.
 disable-vanilla-advancements: false
-# If vanilla advancements are disable, do we also disable recipes. Most of the time, we don't. Works from version 1.20.2 to latest.
+# If vanilla advancements are disabled, whether to also disable advancements that unlock recipes. Works from version 1.20.2 to latest.
 disable-vanilla-advancements-recipes: false
 
 # Database settings

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
                         <doclint>all,-missing</doclint>
                         <failOnWarnings>true</failOnWarnings>
                         <links>
-                            <link>https://frengor.com/javadocs/EventManagerAPI/build-server/</link>
+                            <!-- <link>https://frengor.com/javadocs/EventManagerAPI/build-server/</link> -->
                             <link>https://javadoc.io/doc/org.jetbrains/annotations/22.0.0/</link>
                             <link>https://javadoc.io/static/net.md-5/bungeecord-chat/1.16-R0.4/</link>
                             <link>https://hub.spigotmc.org/javadocs/spigot/</link>


### PR DESCRIPTION
My issue was that `disable-vanilla-advancements: true` disable all advancements, including the one that are used to unlock recipes.
For example, when getting a wood log, the plank recipe don't show up in the recipe book while the player haven't made planks at least once.

The solution that I found was to add a new boolean in the config to choose if vanilla recipes advancement should be disabled to, or just the other ones. `disable-vanilla-advancements-recipes: false`
I can change the names if you prefer an other var name, I've tryed to follow the existing name.

I've tested it with the parameter `true` and `false` on 1.21.4.
It have the same code for 1.20.2+ versions, so it should work with any version between 1.20.2 & 1.21.4.