### PR TITLE
Update to 2.7.2

### DIFF
--- a/Commands/CommandAPI-10.1.2/pom.xml
+++ b/Commands/CommandAPI-10.1.2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-10.1.2</artifactId>

--- a/Commands/CommandAPI-10.1.2/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v10_1_2/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-10.1.2/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v10_1_2/UltimateAdvancementAPICommand.java
@@ -3,6 +3,7 @@ package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v10_1_2;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import com.fren_gor.ultimateAdvancementAPI.commands.CommandsCommon;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.BooleanArgument;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
@@ -26,9 +26,11 @@ import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v10_1_2.Ad
 public class UltimateAdvancementAPICommand {
 
     private final AdvancementMain main;
+    private final CommandsCommon<WrapperCommandSyntaxException> commandsCommon;
 
     protected UltimateAdvancementAPICommand(@NotNull AdvancementMain main) {
         this.main = Objects.requireNonNull(main, "AdvancementMain is null.");
+        this.commandsCommon = new CommandsCommon<>(main, CommandAPI::failWithString);
     }
 
     @SuppressWarnings("unchecked")
@@ -40,56 +42,56 @@ public class UltimateAdvancementAPICommand {
         CommandAPICommand grant = new CommandAPICommand("grant").withPermission(PERMISSION_GRANT).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> grantAll(player, player, true)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantAll(player, player, true)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant all <player> [giveRewards]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> grantOne(player, (Advancement) args.get("advancement"), player, true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantOne(player, (Advancement) args.get("advancement"), player, true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         CommandAPICommand revoke = new CommandAPICommand("revoke").withPermission(PERMISSION_REVOKE).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> revokeAll(player, player, false)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeAll(player, player, false)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke all <player> [hideTab]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> [player] [hideTab]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> <player> [hideTab]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> [player]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> <player>");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> revokeOne(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeOne(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
         );
 
         CommandAPICommand progression = new CommandAPICommand("progression").withPermission(PERMISSION_PROGRESSION).executes((sender, args) -> {
@@ -99,17 +101,17 @@ public class UltimateAdvancementAPICommand {
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression get <advancement> <player>");
                 }),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> getProgression(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.getProgression(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
 
                 new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> commandsCommon.setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         mainCommand.withSubcommands(
@@ -120,138 +122,5 @@ public class UltimateAdvancementAPICommand {
 
         mainCommand.withHelp("Command to handle advancements.", "Command to grant/revoke/update player's advancements.");
         mainCommand.register();
-    }
-
-    private void grantAll(CommandSender sender, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantAll(sender, List.of(player), giveRewards);
-    }
-
-    private void grantAll(CommandSender sender, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            if (m.isActive()) {
-                for (Advancement a : m.getAdvancements()) {
-                    for (Player p : players)
-                        a.grant(p, giveRewards);
-                }
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantTab(sender, tab, List.of(player), giveRewards);
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        for (Advancement a : tab.getAdvancements()) {
-            for (Player p : players)
-                a.grant(p, giveRewards);
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantOne(sender, advancement, List.of(player), giveRewards);
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.getAdvancementTab().showTab(p);
-            advancement.grant(p, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeAll(CommandSender sender, Player player, boolean hideTabs) throws WrapperCommandSyntaxException {
-        revokeAll(sender, List.of(player), hideTabs);
-    }
-
-    private void revokeAll(CommandSender sender, Collection<Player> players, boolean hideTabs) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            var advancements = m.getAdvancements();
-            for (Player p : players) {
-                for (Advancement a : advancements) {
-                    a.revoke(p);
-                }
-                if (hideTabs)
-                    m.hideTab(p);
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been revoked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Player player, boolean hideTab) throws WrapperCommandSyntaxException {
-        revokeTab(sender, tab, List.of(player), hideTab);
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean hideTab) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        var advancements = tab.getAdvancements();
-        for (Player p : players) {
-            for (Advancement a : advancements) {
-                a.revoke(p);
-            }
-            if (hideTab)
-                tab.hideTab(p);
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        revokeOne(sender, advancement, List.of(player));
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.revoke(p);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        return getProgression(sender, advancement, List.of(player));
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        int progression = 0;
-        for (Player p : players) {
-            progression = advancement.getProgression(p);
-            sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-        return progression;
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        setProgression(sender, advancement, progression, List.of(player), giveRewards);
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            progression = Math.min(advancement.getMaxProgression(), progression);
-            advancement.setProgression(p, progression, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Set " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression to " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-    }
-
-    private static void validatePlayerArgument(@NotNull Collection<Player> players) throws WrapperCommandSyntaxException {
-        if (players.size() == 0) {
-            throw CommandAPI.failWithString("No player has been provided.");
-        }
     }
 }

--- a/Commands/CommandAPI-11.0.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_0_0/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-11.0.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_0_0/UltimateAdvancementAPICommand.java
@@ -3,6 +3,7 @@ package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import com.fren_gor.ultimateAdvancementAPI.commands.CommandsCommon;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.BooleanArgument;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
@@ -26,9 +26,11 @@ import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0.Ad
 public class UltimateAdvancementAPICommand {
 
     private final AdvancementMain main;
+    private final CommandsCommon<WrapperCommandSyntaxException> commandsCommon;
 
     protected UltimateAdvancementAPICommand(@NotNull AdvancementMain main) {
         this.main = Objects.requireNonNull(main, "AdvancementMain is null.");
+        this.commandsCommon = new CommandsCommon<>(main, CommandAPI::failWithString);
     }
 
     @SuppressWarnings("unchecked")
@@ -40,56 +42,56 @@ public class UltimateAdvancementAPICommand {
         CommandAPICommand grant = new CommandAPICommand("grant").withPermission(PERMISSION_GRANT).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> grantAll(player, player, true)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantAll(player, player, true)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant all <player> [giveRewards]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> grantOne(player, (Advancement) args.get("advancement"), player, true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantOne(player, (Advancement) args.get("advancement"), player, true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         CommandAPICommand revoke = new CommandAPICommand("revoke").withPermission(PERMISSION_REVOKE).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> revokeAll(player, player, false)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeAll(player, player, false)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke all <player> [hideTab]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> [player] [hideTab]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> <player> [hideTab]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> [player]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> <player>");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> revokeOne(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeOne(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
         );
 
         CommandAPICommand progression = new CommandAPICommand("progression").withPermission(PERMISSION_PROGRESSION).executes((sender, args) -> {
@@ -99,17 +101,17 @@ public class UltimateAdvancementAPICommand {
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression get <advancement> <player>");
                 }),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> getProgression(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.getProgression(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
 
                 new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> commandsCommon.setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         mainCommand.withSubcommands(
@@ -120,138 +122,5 @@ public class UltimateAdvancementAPICommand {
 
         mainCommand.withHelp("Command to handle advancements.", "Command to grant/revoke/update player's advancements.");
         mainCommand.register();
-    }
-
-    private void grantAll(CommandSender sender, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantAll(sender, List.of(player), giveRewards);
-    }
-
-    private void grantAll(CommandSender sender, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            if (m.isActive()) {
-                for (Advancement a : m.getAdvancements()) {
-                    for (Player p : players)
-                        a.grant(p, giveRewards);
-                }
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantTab(sender, tab, List.of(player), giveRewards);
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        for (Advancement a : tab.getAdvancements()) {
-            for (Player p : players)
-                a.grant(p, giveRewards);
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantOne(sender, advancement, List.of(player), giveRewards);
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.getAdvancementTab().showTab(p);
-            advancement.grant(p, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeAll(CommandSender sender, Player player, boolean hideTabs) throws WrapperCommandSyntaxException {
-        revokeAll(sender, List.of(player), hideTabs);
-    }
-
-    private void revokeAll(CommandSender sender, Collection<Player> players, boolean hideTabs) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            var advancements = m.getAdvancements();
-            for (Player p : players) {
-                for (Advancement a : advancements) {
-                    a.revoke(p);
-                }
-                if (hideTabs)
-                    m.hideTab(p);
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been revoked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Player player, boolean hideTab) throws WrapperCommandSyntaxException {
-        revokeTab(sender, tab, List.of(player), hideTab);
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean hideTab) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        var advancements = tab.getAdvancements();
-        for (Player p : players) {
-            for (Advancement a : advancements) {
-                a.revoke(p);
-            }
-            if (hideTab)
-                tab.hideTab(p);
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        revokeOne(sender, advancement, List.of(player));
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.revoke(p);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        return getProgression(sender, advancement, List.of(player));
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        int progression = 0;
-        for (Player p : players) {
-            progression = advancement.getProgression(p);
-            sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-        return progression;
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        setProgression(sender, advancement, progression, List.of(player), giveRewards);
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            progression = Math.min(advancement.getMaxProgression(), progression);
-            advancement.setProgression(p, progression, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Set " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression to " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-    }
-
-    private static void validatePlayerArgument(@NotNull Collection<Player> players) throws WrapperCommandSyntaxException {
-        if (players.size() == 0) {
-            throw CommandAPI.failWithString("No player has been provided.");
-        }
     }
 }

--- a/Commands/CommandAPI-11.1.0/pom.xml
+++ b/Commands/CommandAPI-11.1.0/pom.xml
@@ -10,8 +10,8 @@
         <version>2.7.1</version>
     </parent>
 
-    <artifactId>ultimateadvancementapi-commands-commandapi-11.0.0</artifactId>
-    <name>UltimateAdvancementAPI-Commands-CommandAPI-11.0.0</name>
+    <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
+    <name>UltimateAdvancementAPI-Commands-CommandAPI-11.1.0</name>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-spigot-core</artifactId>
-            <version>11.0.0</version>
+            <version>11.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Commands/CommandAPI-11.1.0/pom.xml
+++ b/Commands/CommandAPI-11.1.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>

--- a/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/AdvancementArgument.java
+++ b/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/AdvancementArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;

--- a/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/AdvancementTabArgument.java
+++ b/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/AdvancementTabArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;

--- a/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/CommandAPIManager.java
+++ b/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/CommandAPIManager.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class CommandAPIManager implements ILoadable {
@@ -40,6 +39,7 @@ public class CommandAPIManager implements ILoadable {
         CommandAPI.onLoad(config
                 .verboseOutput(false)
                 .silentLogs(true)
+                .enableNetworking(false)
                 .setNamespace(plugin.getName().toLowerCase(Locale.ENGLISH)) // Plugin names contain only latin characters present in english
         );
 
@@ -53,12 +53,14 @@ public class CommandAPIManager implements ILoadable {
 
     @Override
     public void onDisable() {
-        Stream.concat(
-                CommandAPI.getRegisteredCommands().stream().map(RegisteredCommand::commandName),
-                CommandAPI.getRegisteredCommands().stream().flatMap(cmd -> Arrays.stream(cmd.aliases()))
-        ).distinct().forEach(command -> {
-            CommandAPI.unregister(command, true);
-        });
+        if (!MojangMappingsHandler.isMojangMapped()) { // Don't run command unregistration on Paper
+            Stream.concat(
+                    CommandAPI.getRegisteredCommands().stream().map(RegisteredCommand::commandName),
+                    CommandAPI.getRegisteredCommands().stream().flatMap(cmd -> Arrays.stream(cmd.aliases()))
+            ).distinct().forEach(command -> {
+                CommandAPI.unregister(command, true);
+            });
+        }
         CommandAPI.onDisable();
     }
 }

--- a/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-11.1.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_1_0/UltimateAdvancementAPICommand.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0.AdvancementArgument.getAdvancementArgument;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_0_0.AdvancementTabArgument.getAdvancementTabArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0.AdvancementArgument.getAdvancementArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0.AdvancementTabArgument.getAdvancementTabArgument;
 
 public class UltimateAdvancementAPICommand {
 

--- a/Commands/CommandAPI-9.3.0/pom.xml
+++ b/Commands/CommandAPI-9.3.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9.3.0</artifactId>

--- a/Commands/CommandAPI-9.3.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_3_0/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-9.3.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_3_0/UltimateAdvancementAPICommand.java
@@ -3,6 +3,7 @@ package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_3_0;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import com.fren_gor.ultimateAdvancementAPI.commands.CommandsCommon;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.BooleanArgument;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
@@ -26,9 +26,11 @@ import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_3_0.Adv
 public class UltimateAdvancementAPICommand {
 
     private final AdvancementMain main;
+    private final CommandsCommon<WrapperCommandSyntaxException> commandsCommon;
 
     protected UltimateAdvancementAPICommand(@NotNull AdvancementMain main) {
         this.main = Objects.requireNonNull(main, "AdvancementMain is null.");
+        this.commandsCommon = new CommandsCommon<>(main, CommandAPI::failWithString);
     }
 
     @SuppressWarnings("unchecked")
@@ -40,56 +42,56 @@ public class UltimateAdvancementAPICommand {
         CommandAPICommand grant = new CommandAPICommand("grant").withPermission(PERMISSION_GRANT).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> grantAll(player, player, true)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantAll(player, player, true)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant all <player> [giveRewards]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> grantOne(player, (Advancement) args.get("advancement"), player, true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantOne(player, (Advancement) args.get("advancement"), player, true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         CommandAPICommand revoke = new CommandAPICommand("revoke").withPermission(PERMISSION_REVOKE).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> revokeAll(player, player, false)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeAll(player, player, false)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke all <player> [hideTab]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> [player] [hideTab]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> <player> [hideTab]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> [player]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> <player>");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> revokeOne(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeOne(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
         );
 
         CommandAPICommand progression = new CommandAPICommand("progression").withPermission(PERMISSION_PROGRESSION).executes((sender, args) -> {
@@ -99,17 +101,17 @@ public class UltimateAdvancementAPICommand {
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression get <advancement> <player>");
                 }),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> getProgression(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.getProgression(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
 
                 new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> commandsCommon.setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         mainCommand.withSubcommands(
@@ -120,138 +122,5 @@ public class UltimateAdvancementAPICommand {
 
         mainCommand.withHelp("Command to handle advancements.", "Command to grant/revoke/update player's advancements.");
         mainCommand.register();
-    }
-
-    private void grantAll(CommandSender sender, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantAll(sender, List.of(player), giveRewards);
-    }
-
-    private void grantAll(CommandSender sender, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            if (m.isActive()) {
-                for (Advancement a : m.getAdvancements()) {
-                    for (Player p : players)
-                        a.grant(p, giveRewards);
-                }
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantTab(sender, tab, List.of(player), giveRewards);
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        for (Advancement a : tab.getAdvancements()) {
-            for (Player p : players)
-                a.grant(p, giveRewards);
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantOne(sender, advancement, List.of(player), giveRewards);
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.getAdvancementTab().showTab(p);
-            advancement.grant(p, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeAll(CommandSender sender, Player player, boolean hideTabs) throws WrapperCommandSyntaxException {
-        revokeAll(sender, List.of(player), hideTabs);
-    }
-
-    private void revokeAll(CommandSender sender, Collection<Player> players, boolean hideTabs) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            var advancements = m.getAdvancements();
-            for (Player p : players) {
-                for (Advancement a : advancements) {
-                    a.revoke(p);
-                }
-                if (hideTabs)
-                    m.hideTab(p);
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been revoked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Player player, boolean hideTab) throws WrapperCommandSyntaxException {
-        revokeTab(sender, tab, List.of(player), hideTab);
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean hideTab) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        var advancements = tab.getAdvancements();
-        for (Player p : players) {
-            for (Advancement a : advancements) {
-                a.revoke(p);
-            }
-            if (hideTab)
-                tab.hideTab(p);
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        revokeOne(sender, advancement, List.of(player));
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.revoke(p);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        return getProgression(sender, advancement, List.of(player));
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        int progression = 0;
-        for (Player p : players) {
-            progression = advancement.getProgression(p);
-            sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-        return progression;
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        setProgression(sender, advancement, progression, List.of(player), giveRewards);
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            progression = Math.min(advancement.getMaxProgression(), progression);
-            advancement.setProgression(p, progression, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Set " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression to " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-    }
-
-    private static void validatePlayerArgument(@NotNull Collection<Player> players) throws WrapperCommandSyntaxException {
-        if (players.size() == 0) {
-            throw CommandAPI.failWithString("No player has been provided.");
-        }
     }
 }

--- a/Commands/CommandAPI-9.7.0/pom.xml
+++ b/Commands/CommandAPI-9.7.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9.7.0</artifactId>

--- a/Commands/CommandAPI-9.7.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_7_0/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-9.7.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v9_7_0/UltimateAdvancementAPICommand.java
@@ -3,6 +3,7 @@ package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_7_0;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import com.fren_gor.ultimateAdvancementAPI.commands.CommandsCommon;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.BooleanArgument;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
@@ -26,9 +26,11 @@ import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v9_7_0.Adv
 public class UltimateAdvancementAPICommand {
 
     private final AdvancementMain main;
+    private final CommandsCommon<WrapperCommandSyntaxException> commandsCommon;
 
     protected UltimateAdvancementAPICommand(@NotNull AdvancementMain main) {
         this.main = Objects.requireNonNull(main, "AdvancementMain is null.");
+        this.commandsCommon = new CommandsCommon<>(main, CommandAPI::failWithString);
     }
 
     @SuppressWarnings("unchecked")
@@ -40,56 +42,56 @@ public class UltimateAdvancementAPICommand {
         CommandAPICommand grant = new CommandAPICommand("grant").withPermission(PERMISSION_GRANT).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> grantAll(player, player, true)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantAll(player, player, true)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant all <player> [giveRewards]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("all").withPermission(PERMISSION_GRANT_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant tab <advancementTab> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantTab(player, (AdvancementTab) args.get("advancementTab"), player, true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_GRANT_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi grant one <advancement> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> grantOne(player, (Advancement) args.get("advancement"), player, true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.grantOne(player, (Advancement) args.get("advancement"), player, true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("one").withPermission(PERMISSION_GRANT_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.grantOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         CommandAPICommand revoke = new CommandAPICommand("revoke").withPermission(PERMISSION_REVOKE).executes((sender, args) -> {
             sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke <all|tab|one> ...");
         }).withSubcommands(
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> revokeAll(player, player, false)).executes((sender, args) -> {
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeAll(player, player, false)).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke all <player> [hideTab]");
                 }),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("all").withPermission(PERMISSION_REVOKE_ALL).withArguments(new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTabs")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeAll(sender, (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> [player] [hideTab]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke tab <advancementTab> <player> [hideTab]");
                 }),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
-                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeTab(player, (AdvancementTab) args.get("advancementTab"), player, false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), false)),
+                new CommandAPICommand("tab").withPermission(PERMISSION_REVOKE_TAB).withArguments(getAdvancementTabArgument(main, "advancementTab"), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("hideTab")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeTab(sender, (AdvancementTab) args.get("advancementTab"), (Collection<Player>) args.get("player"), (boolean) args.get("hideTabs"))),
 
                 new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> [player]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi revoke one <advancement> <player>");
                 }),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> revokeOne(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.revokeOne(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("one").withPermission(PERMISSION_REVOKE_ONE).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.revokeOne(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player")))
         );
 
         CommandAPICommand progression = new CommandAPICommand("progression").withPermission(PERMISSION_PROGRESSION).executes((sender, args) -> {
@@ -99,17 +101,17 @@ public class UltimateAdvancementAPICommand {
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression get <advancement> <player>");
                 }),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> getProgression(player, (Advancement) args.get("advancement"), player)),
-                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement")).executesPlayer((Player player, CommandArguments args) -> commandsCommon.getProgression(player, (Advancement) args.get("advancement"), player)),
+                new CommandAPICommand("get").withPermission(PERMISSION_PROGRESSION_GET).withArguments(getAdvancementArgument(main, "advancement"), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.getProgression(sender, (Advancement) args.get("advancement"), (Collection<Player>) args.get("player"))),
 
                 new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).executesPlayer((player, args) -> {
                     player.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> [player] [giveRewards]");
                 }).executes((sender, args) -> {
                     sender.sendMessage(ChatColor.RED + "Usage: /ultimateadvancementapi progression set <advancement> <progression> <player> [giveRewards]");
                 }),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
-                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0)).executesPlayer((Player player, CommandArguments args) -> commandsCommon.setProgression(player, (Advancement) args.get("advancement"), (int) args.get("progression"), player, true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), true)),
+                new CommandAPICommand("set").withPermission(PERMISSION_PROGRESSION_SET).withArguments(getAdvancementArgument(main, "advancement"), new IntegerArgument("progression", 0), new EntitySelectorArgument.ManyPlayers("player"), new BooleanArgument("giveRewards")).executes((CommandSender sender, CommandArguments args) -> commandsCommon.setProgression(sender, (Advancement) args.get("advancement"), (int) args.get("progression"), (Collection<Player>) args.get("player"), (boolean) args.get("giveRewards")))
         );
 
         mainCommand.withSubcommands(
@@ -120,138 +122,5 @@ public class UltimateAdvancementAPICommand {
 
         mainCommand.withHelp("Command to handle advancements.", "Command to grant/revoke/update player's advancements.");
         mainCommand.register();
-    }
-
-    private void grantAll(CommandSender sender, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantAll(sender, List.of(player), giveRewards);
-    }
-
-    private void grantAll(CommandSender sender, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            if (m.isActive()) {
-                for (Advancement a : m.getAdvancements()) {
-                    for (Player p : players)
-                        a.grant(p, giveRewards);
-                }
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantTab(sender, tab, List.of(player), giveRewards);
-    }
-
-    private void grantTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        for (Advancement a : tab.getAdvancements()) {
-            for (Player p : players)
-                a.grant(p, giveRewards);
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        grantOne(sender, advancement, List.of(player), giveRewards);
-    }
-
-    private void grantOne(CommandSender sender, Advancement advancement, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.getAdvancementTab().showTab(p);
-            advancement.grant(p, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been unlocked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeAll(CommandSender sender, Player player, boolean hideTabs) throws WrapperCommandSyntaxException {
-        revokeAll(sender, List.of(player), hideTabs);
-    }
-
-    private void revokeAll(CommandSender sender, Collection<Player> players, boolean hideTabs) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (AdvancementTab m : main.getTabs()) {
-            var advancements = m.getAdvancements();
-            for (Player p : players) {
-                for (Advancement a : advancements) {
-                    a.revoke(p);
-                }
-                if (hideTabs)
-                    m.hideTab(p);
-            }
-        }
-        for (Player p : players)
-            sender.sendMessage(ChatColor.GREEN + "All advancement has been revoked to " + ChatColor.YELLOW + p.getName());
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Player player, boolean hideTab) throws WrapperCommandSyntaxException {
-        revokeTab(sender, tab, List.of(player), hideTab);
-    }
-
-    private void revokeTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean hideTab) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        if (!tab.isActive()) {
-            throw CommandAPI.failWithString("Advancement tab is not active.");
-        }
-        var advancements = tab.getAdvancements();
-        for (Player p : players) {
-            for (Advancement a : advancements) {
-                a.revoke(p);
-            }
-            if (hideTab)
-                tab.hideTab(p);
-            sender.sendMessage(ChatColor.GREEN + "All advancement of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        revokeOne(sender, advancement, List.of(player));
-    }
-
-    private void revokeOne(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            advancement.revoke(p);
-            sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
-        }
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Player player) throws WrapperCommandSyntaxException {
-        return getProgression(sender, advancement, List.of(player));
-    }
-
-    private int getProgression(CommandSender sender, Advancement advancement, Collection<Player> players) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        int progression = 0;
-        for (Player p : players) {
-            progression = advancement.getProgression(p);
-            sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-        return progression;
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Player player, boolean giveRewards) throws WrapperCommandSyntaxException {
-        setProgression(sender, advancement, progression, List.of(player), giveRewards);
-    }
-
-    private void setProgression(CommandSender sender, Advancement advancement, int progression, Collection<Player> players, boolean giveRewards) throws WrapperCommandSyntaxException {
-        validatePlayerArgument(players);
-        for (Player p : players) {
-            progression = Math.min(advancement.getMaxProgression(), progression);
-            advancement.setProgression(p, progression, giveRewards);
-            sender.sendMessage(ChatColor.GREEN + "Set " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression to " + ChatColor.YELLOW + progression + '/' + advancement.getMaxProgression());
-        }
-    }
-
-    private static void validatePlayerArgument(@NotNull Collection<Player> players) throws WrapperCommandSyntaxException {
-        if (players.size() == 0) {
-            throw CommandAPI.failWithString("No player has been provided.");
-        }
     }
 }

--- a/Commands/Common/pom.xml
+++ b/Commands/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-common</artifactId>

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
@@ -59,15 +59,16 @@ public enum CommandAPIVersion {
                     "v1_21_R4"
             )
     ),
-    LATEST("11.0.0",
+    LATEST("11.1.0",
             "commandapi-spigot-shade",
             "commandapi-paper-shade",
-            "Fj53byvXMUNTOWVGshgqXxcvCz5Q7K9Ipk9LHlv+FNM=",
-            "g0vXatzD0v726X589IJRv4LsUaANZsS5s7WQXMvWKds=",
-            "11_0_0",
+            "E0rUSMwJKIHP5skpdscHMhq4VslVNnfcxh4QnY8N2Vw=",
+            "WG0DkQHBm8me54fVf5e3lVY+50qwvvOFhApxT+na+Ho=",
+            "11_1_0",
             List.of(
                     "v1_21_R5",
-                    "v1_21_R6"
+                    "v1_21_R6",
+                    "v1_21_R7"
             )
     );
 

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandsCommon.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandsCommon.java
@@ -200,6 +200,7 @@ public final class CommandsCommon<Error extends Exception> {
     private boolean runSafely(CommandSender sender, Runnable action, Supplier<String> errorGenerator) {
         try {
             action.run();
+        } catch (UnsupportedOperationException ignored) {
         } catch (Exception e) {
             String error = errorGenerator.get();
             main.getLogger().log(Level.SEVERE, error, e);

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandsCommon.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandsCommon.java
@@ -87,11 +87,13 @@ public final class CommandsCommon<Error extends Exception> {
     public void grantOne(CommandSender sender, Advancement advancement, Collection<Player> players, boolean giveRewards) throws Error {
         validatePlayerArgument(players);
         for (Player p : players) {
-            runSafely(sender, () -> {
+            boolean failed = runSafely(sender, () -> {
                 advancement.getAdvancementTab().showTab(p);
                 advancement.grant(p, giveRewards);
-                sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been granted to " + ChatColor.YELLOW + p.getName());
             }, () -> "Could not grant advancement " + advancement + " to " + p.getName());
+            if (!failed) {
+                sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been granted to " + ChatColor.YELLOW + p.getName());
+            }
         }
     }
 
@@ -155,10 +157,12 @@ public final class CommandsCommon<Error extends Exception> {
     public void revokeOne(CommandSender sender, Advancement advancement, Collection<Player> players) throws Error {
         validatePlayerArgument(players);
         for (Player p : players) {
-            runSafely(sender, () -> {
+            boolean failed = runSafely(sender, () -> {
                 advancement.revoke(p);
-                sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
             }, () -> "Could not revoke advancement " + advancement + " to " + p.getName());
+            if (!failed) {
+                sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
+            }
         }
     }
 
@@ -170,12 +174,14 @@ public final class CommandsCommon<Error extends Exception> {
         validatePlayerArgument(players);
         int[] progression = {0}; // Avoid lambda error
         for (Player p : players) {
-            runSafely(sender, () -> {
+            boolean failed = runSafely(sender, () -> {
                 progression[0] = advancement.getProgression(p);
-                sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression[0] + '/' + advancement.getMaxProgression());
             }, () -> {
                 return "Could not get " + p.getName() + "'s progression of advancement " + advancement;
             });
+            if (!failed) {
+                sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression[0] + '/' + advancement.getMaxProgression());
+            }
         }
         return progression[0];
     }
@@ -188,12 +194,14 @@ public final class CommandsCommon<Error extends Exception> {
         validatePlayerArgument(players);
         final int progr = Math.min(advancement.getMaxProgression(), progression);
         for (Player p : players) {
-            runSafely(sender, () -> {
+            boolean failed = runSafely(sender, () -> {
                 advancement.setProgression(p, progr, giveRewards);
-                sender.sendMessage(ChatColor.GREEN + "Progression of " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " has been set to " + ChatColor.YELLOW + progr + '/' + advancement.getMaxProgression());
             }, () -> {
                 return "Could not set " + p.getName() + "'s progression of advancement " + advancement + " to " + progr + '/' + advancement.getMaxProgression();
             });
+            if (!failed) {
+                sender.sendMessage(ChatColor.GREEN + "Progression of " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " has been set to " + ChatColor.YELLOW + progr + '/' + advancement.getMaxProgression());
+            }
         }
     }
 

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandsCommon.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandsCommon.java
@@ -1,0 +1,226 @@
+package com.fren_gor.ultimateAdvancementAPI.commands;
+
+import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
+import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
+import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+/**
+ * Common code for command implementations.
+ *
+ * @hidden
+ */
+@Internal
+public final class CommandsCommon<Error extends Exception> {
+
+    private final AdvancementMain main;
+    private final CommandAPIMethods<Error> commandAPI;
+
+    public CommandsCommon(@NotNull AdvancementMain main, @NotNull CommandAPIMethods<Error> commandAPI) {
+        this.main = Objects.requireNonNull(main, "AdvancementMain is null.");
+        this.commandAPI = Objects.requireNonNull(commandAPI, "CommandAPIMethods is null.");
+    }
+
+    public void grantAll(CommandSender sender, Player player, boolean giveRewards) throws Error {
+        grantAll(sender, List.of(player), giveRewards);
+    }
+
+    public void grantAll(CommandSender sender, Collection<Player> players, boolean giveRewards) throws Error {
+        validatePlayerArgument(players);
+        boolean failed = false;
+        for (AdvancementTab m : main.getTabs()) {
+            if (m.isActive()) {
+                for (Advancement a : m.getAdvancements()) {
+                    for (Player p : players) {
+                        failed |= runSafely(sender, () -> a.grant(p, giveRewards), () -> "Could not grant advancement " + a + " to " + p.getName());
+                    }
+                }
+            }
+        }
+        for (Player p : players) {
+            if (failed) {
+                sender.sendMessage(ChatColor.RED + "Could not grant every advancement to " + p.getName());
+            } else {
+                sender.sendMessage(ChatColor.GREEN + "All advancements have been granted to " + ChatColor.YELLOW + p.getName());
+            }
+        }
+    }
+
+    public void grantTab(CommandSender sender, AdvancementTab tab, Player player, boolean giveRewards) throws Error {
+        grantTab(sender, tab, List.of(player), giveRewards);
+    }
+
+    public void grantTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean giveRewards) throws Error {
+        validatePlayerArgument(players);
+        if (!tab.isActive()) {
+            throw commandAPI.failWithString("Advancement tab is not active.");
+        }
+        boolean failed = false;
+        for (Advancement a : tab.getAdvancements()) {
+            for (Player p : players) {
+                failed |= runSafely(sender, () -> a.grant(p, giveRewards), () -> "Could not grant advancement " + a + " to " + p.getName());
+            }
+        }
+        for (Player p : players) {
+            if (failed) {
+                sender.sendMessage(ChatColor.RED + "Could not grant every advancement of tab " + tab + " to " + p.getName());
+            } else {
+                sender.sendMessage(ChatColor.GREEN + "All advancements of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " have been granted to " + ChatColor.YELLOW + p.getName());
+            }
+        }
+    }
+
+    public void grantOne(CommandSender sender, Advancement advancement, Player player, boolean giveRewards) throws Error {
+        grantOne(sender, advancement, List.of(player), giveRewards);
+    }
+
+    public void grantOne(CommandSender sender, Advancement advancement, Collection<Player> players, boolean giveRewards) throws Error {
+        validatePlayerArgument(players);
+        for (Player p : players) {
+            runSafely(sender, () -> {
+                advancement.getAdvancementTab().showTab(p);
+                advancement.grant(p, giveRewards);
+                sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement.getKey() + ChatColor.GREEN + " has been granted to " + ChatColor.YELLOW + p.getName());
+            }, () -> "Could not grant advancement " + advancement + " to " + p.getName());
+        }
+    }
+
+    public void revokeAll(CommandSender sender, Player player, boolean hideTabs) throws Error {
+        revokeAll(sender, List.of(player), hideTabs);
+    }
+
+    public void revokeAll(CommandSender sender, Collection<Player> players, boolean hideTabs) throws Error {
+        validatePlayerArgument(players);
+        boolean failed = false;
+        for (AdvancementTab m : main.getTabs()) {
+            var advancements = m.getAdvancements();
+            for (Player p : players) {
+                for (Advancement a : advancements) {
+                    failed |= runSafely(sender, () -> a.revoke(p), () -> "Could not revoke advancement " + a + " to " + p.getName());
+                }
+                if (hideTabs) {
+                    runSafely(sender, () -> m.hideTab(p), () -> "Could not hide advancement tab " + m + " to " + p.getName());
+                }
+            }
+        }
+        for (Player p : players) {
+            if (failed) {
+                sender.sendMessage(ChatColor.RED + "Could not revoke every advancement to " + p.getName());
+            } else {
+                sender.sendMessage(ChatColor.GREEN + "All advancements have been revoked to " + ChatColor.YELLOW + p.getName());
+            }
+        }
+    }
+
+    public void revokeTab(CommandSender sender, AdvancementTab tab, Player player, boolean hideTab) throws Error {
+        revokeTab(sender, tab, List.of(player), hideTab);
+    }
+
+    public void revokeTab(CommandSender sender, AdvancementTab tab, Collection<Player> players, boolean hideTab) throws Error {
+        validatePlayerArgument(players);
+        if (!tab.isActive()) {
+            throw commandAPI.failWithString("Advancement tab is not active.");
+        }
+        var advancements = tab.getAdvancements();
+        for (Player p : players) {
+            boolean failed = false;
+            for (Advancement a : advancements) {
+                failed |= runSafely(sender, () -> a.revoke(p), () -> "Could not revoke advancement " + a + " to " + p.getName());
+            }
+            if (hideTab) {
+                runSafely(sender, () -> tab.hideTab(p), () -> "Could not hide advancement tab " + tab + " to " + p.getName());
+            }
+            if (failed) {
+                sender.sendMessage(ChatColor.RED + "Could not revoke every advancement of tab " + tab + " to " + p.getName());
+            } else {
+                sender.sendMessage(ChatColor.GREEN + "All advancements of tab " + ChatColor.YELLOW + tab + ChatColor.GREEN + " have been revoked to " + ChatColor.YELLOW + p.getName());
+            }
+        }
+    }
+
+    public void revokeOne(CommandSender sender, Advancement advancement, Player player) throws Error {
+        revokeOne(sender, advancement, List.of(player));
+    }
+
+    public void revokeOne(CommandSender sender, Advancement advancement, Collection<Player> players) throws Error {
+        validatePlayerArgument(players);
+        for (Player p : players) {
+            runSafely(sender, () -> {
+                advancement.revoke(p);
+                sender.sendMessage(ChatColor.GREEN + "Advancement " + ChatColor.YELLOW + advancement + ChatColor.GREEN + " has been revoked to " + ChatColor.YELLOW + p.getName());
+            }, () -> "Could not revoke advancement " + advancement + " to " + p.getName());
+        }
+    }
+
+    public int getProgression(CommandSender sender, Advancement advancement, Player player) throws Error {
+        return getProgression(sender, advancement, List.of(player));
+    }
+
+    public int getProgression(CommandSender sender, Advancement advancement, Collection<Player> players) throws Error {
+        validatePlayerArgument(players);
+        int[] progression = {0}; // Avoid lambda error
+        for (Player p : players) {
+            runSafely(sender, () -> {
+                progression[0] = advancement.getProgression(p);
+                sender.sendMessage(ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " progression is " + ChatColor.YELLOW + progression[0] + '/' + advancement.getMaxProgression());
+            }, () -> {
+                return "Could not get " + p.getName() + "'s progression of advancement " + advancement;
+            });
+        }
+        return progression[0];
+    }
+
+    public void setProgression(CommandSender sender, Advancement advancement, int progression, Player player, boolean giveRewards) throws Error {
+        setProgression(sender, advancement, progression, List.of(player), giveRewards);
+    }
+
+    public void setProgression(CommandSender sender, Advancement advancement, int progression, Collection<Player> players, boolean giveRewards) throws Error {
+        validatePlayerArgument(players);
+        final int progr = Math.min(advancement.getMaxProgression(), progression);
+        for (Player p : players) {
+            runSafely(sender, () -> {
+                advancement.setProgression(p, progr, giveRewards);
+                sender.sendMessage(ChatColor.GREEN + "Progression of " + ChatColor.YELLOW + p.getName() + ChatColor.GREEN + " has been set to " + ChatColor.YELLOW + progr + '/' + advancement.getMaxProgression());
+            }, () -> {
+                return "Could not set " + p.getName() + "'s progression of advancement " + advancement + " to " + progr + '/' + advancement.getMaxProgression();
+            });
+        }
+    }
+
+    private boolean runSafely(CommandSender sender, Runnable action, Supplier<String> errorGenerator) {
+        try {
+            action.run();
+        } catch (Exception e) {
+            String error = errorGenerator.get();
+            main.getLogger().log(Level.SEVERE, error, e);
+            sender.sendMessage(ChatColor.RED + error);
+            return true;
+        }
+        return false;
+    }
+
+    private void validatePlayerArgument(@NotNull Collection<Player> players) throws Error {
+        if (players.isEmpty()) {
+            throw commandAPI.failWithString("No player has been provided.");
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    @Internal
+    @FunctionalInterface
+    public interface CommandAPIMethods<Error extends Exception> {
+        Error failWithString(String string);
+    }
+}

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-11.0.0</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-distribution</artifactId>

--- a/Commands/DistributionMojangMapped/pom.xml
+++ b/Commands/DistributionMojangMapped/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-11.0.0</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/DistributionMojangMapped/pom.xml
+++ b/Commands/DistributionMojangMapped/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-distribution-mojang-mapped</artifactId>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>ultimateadvancementapi-parent</artifactId>
         <groupId>com.frengor</groupId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-parent</artifactId>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -25,7 +25,7 @@
         <module>CommandAPI-9.3.0</module>
         <module>CommandAPI-9.7.0</module>
         <module>CommandAPI-10.1.2</module>
-        <module>CommandAPI-11.0.0</module>
+        <module>CommandAPI-11.1.0</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
     </modules>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-common</artifactId>

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/Advancement.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/advancement/Advancement.java
@@ -564,7 +564,7 @@ public abstract class Advancement {
         Preconditions.checkNotNull(player, "Player is null.");
 
         // Send complete messages
-        Boolean gameRule = player.getWorld().getGameRuleValue(GameRule.ANNOUNCE_ADVANCEMENTS);
+        Boolean gameRule = player.getWorld().getGameRuleValue(AdvancementUtils.SHOW_ADVANCEMENT_MESSAGES_GAMERULE);
         if (display.doesAnnounceToChat() && (gameRule == null || gameRule)) {
             BaseComponent[] msg = getAnnounceMessage(player);
             if (msg != null)

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/AdvancementUtils.java
@@ -21,6 +21,7 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.ComponentBuilder.FormatRetention;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -36,6 +37,11 @@ import java.util.Set;
 import java.util.UUID;
 
 public class AdvancementUtils {
+
+    /**
+     * The {@code show_advancement_messages} game rule (previously called {@code announceAdvancements}).
+     */
+    public static final GameRule<Boolean> SHOW_ADVANCEMENT_MESSAGES_GAMERULE = getShowAdvancementMessagesGamerule();
 
     public static final MinecraftKeyWrapper ROOT_KEY, NOTIFICATION_KEY;
     private static final String ADV_DESCRIPTION = "\n§7A notification.";
@@ -289,6 +295,19 @@ public class AdvancementUtils {
     public static TeamProgression progressionFromUUID(@NotNull UUID uuid, @NotNull AdvancementTab tab) {
         Preconditions.checkNotNull(uuid, "UUID is null.");
         return tab.getDatabaseManager().getTeamProgression(uuid);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static GameRule<Boolean> getShowAdvancementMessagesGamerule() {
+        try {
+            // Spigot 1.21.11+
+            return (GameRule<Boolean>) GameRule.class.getDeclaredField("SHOW_ADVANCEMENT_MESSAGES").get(null);
+        } catch (NoSuchFieldException e) {
+            // Spigot <= 1.21.10, Paper all versions
+            return GameRule.ANNOUNCE_ADVANCEMENTS;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private AdvancementUtils() {

--- a/Distribution/API/pom.xml
+++ b/Distribution/API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi</artifactId>

--- a/Distribution/Commands/pom.xml
+++ b/Distribution/Commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands</artifactId>

--- a/Distribution/Shadeable/pom.xml
+++ b/Distribution/Shadeable/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-shadeable</artifactId>

--- a/Distribution/pom.xml
+++ b/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-distribution</artifactId>

--- a/NMS/1_15_R1/pom.xml
+++ b/NMS/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_15_R1</artifactId>

--- a/NMS/1_16_R1/pom.xml
+++ b/NMS/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R1</artifactId>

--- a/NMS/1_16_R2/pom.xml
+++ b/NMS/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R2</artifactId>

--- a/NMS/1_16_R3/pom.xml
+++ b/NMS/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R3</artifactId>

--- a/NMS/1_17_R1/pom.xml
+++ b/NMS/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_17_R1</artifactId>

--- a/NMS/1_18_R1/pom.xml
+++ b/NMS/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>

--- a/NMS/1_18_R2/pom.xml
+++ b/NMS/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>

--- a/NMS/1_19_R1/pom.xml
+++ b/NMS/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>

--- a/NMS/1_19_R2/pom.xml
+++ b/NMS/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>

--- a/NMS/1_19_R3/pom.xml
+++ b/NMS/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>

--- a/NMS/1_20_R1/pom.xml
+++ b/NMS/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>

--- a/NMS/1_20_R2/pom.xml
+++ b/NMS/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R2</artifactId>

--- a/NMS/1_20_R3/pom.xml
+++ b/NMS/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R3</artifactId>

--- a/NMS/1_20_R4/pom.xml
+++ b/NMS/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R4</artifactId>

--- a/NMS/1_21_R1/pom.xml
+++ b/NMS/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R1</artifactId>

--- a/NMS/1_21_R2/pom.xml
+++ b/NMS/1_21_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R2</artifactId>

--- a/NMS/1_21_R3/pom.xml
+++ b/NMS/1_21_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R3</artifactId>

--- a/NMS/1_21_R4/pom.xml
+++ b/NMS/1_21_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R4</artifactId>

--- a/NMS/1_21_R5/pom.xml
+++ b/NMS/1_21_R5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R5</artifactId>

--- a/NMS/1_21_R6/pom.xml
+++ b/NMS/1_21_R6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R6</artifactId>

--- a/NMS/1_21_R7/pom.xml
+++ b/NMS/1_21_R7/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.frengor</groupId>
+        <artifactId>ultimateadvancementapi-nms-parent</artifactId>
+        <version>2.7.1</version>
+    </parent>
+
+    <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
+    <name>UltimateAdvancementAPI-NMS-1_21_R7</name>
+    <url>${parent.url}</url>
+    <packaging>jar</packaging>
+
+    <properties>
+        <mc-version>1.21.11-R0.1-SNAPSHOT</mc-version>
+    </properties>
+
+    <dependencies>
+        <!-- Spigot API -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spigot -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+            <classifier>remapped-mojang</classifier>
+        </dependency>
+
+        <!-- NMS Common Module -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>../..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>LGPL</include>
+                    <include>NOTICE</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-mojang-mapped-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.md-5</groupId>
+                <artifactId>specialsource-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/NMS/1_21_R7/pom.xml
+++ b/NMS/1_21_R7/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/MinecraftKeyWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/MinecraftKeyWrapper_v1_21_R7.java
@@ -1,0 +1,46 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import net.minecraft.IdentifierException;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class MinecraftKeyWrapper_v1_21_R7 extends MinecraftKeyWrapper {
+
+    private final Identifier key;
+
+    public MinecraftKeyWrapper_v1_21_R7(@NotNull Object key) {
+        this.key = (Identifier) key;
+    }
+
+    public MinecraftKeyWrapper_v1_21_R7(@NotNull String namespace, @NotNull String key) {
+        try {
+            this.key = Identifier.fromNamespaceAndPath(namespace, key);
+        } catch (IdentifierException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    @Override
+    @NotNull
+    public String getNamespace() {
+        return key.getNamespace();
+    }
+
+    @Override
+    @NotNull
+    public String getKey() {
+        return key.getPath();
+    }
+
+    @Override
+    public int compareTo(@NotNull MinecraftKeyWrapper obj) {
+        return key.compareTo((Identifier) obj.toNMS());
+    }
+
+    @Override
+    @NotNull
+    public Identifier toNMS() {
+        return key;
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/Util.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/Util.java
@@ -1,0 +1,121 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.CriterionProgress;
+import net.minecraft.advancements.criterion.ImpossibleTrigger;
+import net.minecraft.advancements.criterion.ImpossibleTrigger.TriggerInstance;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.resources.Identifier;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_21_R7.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class Util {
+
+    public static final Logger ERROR = Logger.getLogger("UltimateAdvancementAPI-NMS");
+
+    @NotNull
+    public static Map<String, Criterion<?>> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
+
+        Map<String, Criterion<?>> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
+        for (int i = 0; i < maxProgression; i++) {
+            advCriteria.put(String.valueOf(i), new Criterion<>(new ImpossibleTrigger(), new TriggerInstance()));
+        }
+
+        return advCriteria;
+    }
+
+    @NotNull
+    public static AdvancementRequirements getAdvancementRequirements(@NotNull Map<String, Criterion<?>> advCriteria) {
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
+
+        List<List<String>> list = new ArrayList<>(advCriteria.size());
+        for (String name : advCriteria.keySet()) {
+            list.add(List.of(name));
+        }
+
+        return new AdvancementRequirements(list);
+    }
+
+    @NotNull
+    public static AdvancementProgress getAdvancementProgress(@NotNull AdvancementHolder mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
+
+        AdvancementProgress advPrg = new AdvancementProgress();
+        advPrg.update(mcAdv.value().requirements());
+
+        for (int i = 0; i < progression; i++) {
+            CriterionProgress criteriaPrg = advPrg.getCriterion(String.valueOf(i));
+            if (criteriaPrg != null) {
+                criteriaPrg.grant();
+            }
+        }
+
+        return advPrg;
+    }
+
+    @NotNull
+    public static Component fromString(@NotNull String string) {
+        if (string == null || string.isEmpty()) {
+            return CommonComponents.EMPTY;
+        }
+        return CraftChatMessage.fromStringOrNull(string, true);
+    }
+
+    @NotNull
+    public static Component fromComponent(@NotNull BaseComponent component) {
+        if (component == null) {
+            return CommonComponents.EMPTY;
+        }
+        Component base = CraftChatMessage.fromJSONOrNull(ComponentSerializer.toString(component));
+        return base == null ? CommonComponents.EMPTY : base;
+    }
+
+    @Nullable
+    public static ClientAsset.ResourceTexture parseBackgroundTexture(@Nullable String backgroundTexture) {
+        if (backgroundTexture == null) {
+            return null;
+        }
+
+        Identifier texturePath = Identifier.parse(backgroundTexture);
+        if (!texturePath.getPath().startsWith("textures/") || !texturePath.getPath().endsWith(".png")) {
+            ERROR.severe("Invalid background texture \"" + backgroundTexture + "\" (the path should be in the form \"textures/**.png\")");
+            return null;
+        }
+
+        Identifier id = texturePath.withPath(path -> {
+            return path.substring("textures/".length(), path.length() - ".png".length());
+        });
+        return new ClientAsset.ResourceTexture(id, texturePath);
+    }
+
+    public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
+        ((CraftPlayer) player).getHandle().connection.send(packet);
+    }
+
+    private Util() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/VanillaAdvancementDisablerWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/VanillaAdvancementDisablerWrapper_v1_21_R7.java
@@ -1,0 +1,184 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.VanillaAdvancementDisablerWrapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementNode;
+import net.minecraft.advancements.AdvancementTree;
+import net.minecraft.advancements.AdvancementTree.Listener;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.ServerAdvancementManager;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.simple.SimpleLogger;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_21_R7.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class VanillaAdvancementDisablerWrapper_v1_21_R7 extends VanillaAdvancementDisablerWrapper {
+
+    private static Logger LOGGER = null;
+    private static Field listener, firstPacket;
+
+    static {
+        try {
+            listener = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == AdvancementTree.Listener.class).findFirst().orElseThrow();
+            listener.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            firstPacket = Arrays.stream(PlayerAdvancements.class.getDeclaredFields()).filter(f -> f.getType() == boolean.class).findFirst().orElseThrow();
+            firstPacket.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Field logger = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == org.slf4j.Logger.class).findFirst().orElseThrow();
+            logger.setAccessible(true);
+            org.slf4j.Logger slf4jLogger = (org.slf4j.Logger) logger.get(null);
+            LOGGER = Arrays.stream(slf4jLogger.getClass().getDeclaredFields()).filter(f -> !Modifier.isStatic(f.getModifiers())).map(f -> {
+                try {
+                    f.setAccessible(true);
+                    if (f.get(slf4jLogger) instanceof Logger log) {
+                        return log;
+                    }
+                } catch (ReflectiveOperationException e) {
+                    e.printStackTrace();
+                }
+                return null;
+            }).filter(Objects::nonNull).findFirst().orElseThrow();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void disableVanillaAdvancements(boolean vanillaAdvancements, boolean vanillaRecipeAdvancements) throws Exception {
+        ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
+        AdvancementTree tree = serverAdvancements.tree();
+
+        if (serverAdvancements.advancements.isEmpty()) {
+            return;
+        }
+
+        final Set<Identifier> removed = Sets.newHashSetWithExpectedSize(serverAdvancements.advancements.size());
+
+        // Inject AdvancementTree listener
+        final Listener old = (Listener) listener.get(tree);
+        try {
+            listener.set(tree, new Listener() {
+                @Override
+                public void onAddAdvancementRoot(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementRoot(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onAddAdvancementTask(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementTask(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onAdvancementsCleared() {
+                    if (old != null)
+                        old.onAdvancementsCleared();
+                }
+            });
+
+            Set<Identifier> locations = new HashSet<>();
+            ImmutableMap.Builder<Identifier, AdvancementHolder> builder = ImmutableMap.builder();
+            for (var entry : serverAdvancements.advancements.entrySet()) {
+                Identifier key = entry.getKey();
+                boolean isRecipe = key.getPath().startsWith("recipes/");
+                if (key.getNamespace().equals("minecraft") && ((vanillaAdvancements && !isRecipe) || (vanillaRecipeAdvancements && isRecipe))) {
+                    locations.add(key);
+                } else {
+                    builder.put(key, entry.getValue());
+                }
+            }
+
+            serverAdvancements.advancements = builder.buildOrThrow();
+
+            final Level oldLevel = disableLogger();
+            try {
+                tree.remove(locations);
+            } finally {
+                // Always restore old logger
+                enableLogger(oldLevel);
+            }
+        } finally {
+            // Always uninject advancement listener
+            listener.set(tree, old);
+        }
+
+        final var removePacket = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), removed, Collections.emptyMap(), false);
+
+        // Remove advancements from players
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            var mcPlayer = ((CraftPlayer) player).getHandle();
+            var advs = mcPlayer.getAdvancements();
+            advs.reload(serverAdvancements);
+            firstPacket.setBoolean(advs, false); // Don't clear every client advancement
+            mcPlayer.connection.send(removePacket);
+        }
+    }
+
+    private static Level disableLogger() {
+        if (LOGGER == null) // Fail-safe if LOGGER could not be found by reflections
+            return null;
+
+        Level old = LOGGER.getLevel();
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(Level.OFF);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(Level.OFF);
+        }
+
+        return old;
+    }
+
+    private static void enableLogger(Level toSet) {
+        if (LOGGER == null || toSet == null) // Fail-safe if LOGGER could not be found by reflections
+            return;
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(toSet);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(toSet);
+        }
+    }
+
+    private VanillaAdvancementDisablerWrapper_v1_21_R7() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/AdvancementDisplayWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/AdvancementDisplayWrapper_v1_21_R7.java
@@ -1,0 +1,98 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.advancements.AdvancementType;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.core.ClientAsset;
+import org.bukkit.craftbukkit.v1_21_R7.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_21_R7.util.CraftChatMessage;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class AdvancementDisplayWrapper_v1_21_R7 extends AdvancementDisplayWrapper {
+
+    private final DisplayInfo display;
+    private final AdvancementFrameTypeWrapper frameType;
+
+    public AdvancementDisplayWrapper_v1_21_R7(@NotNull ItemStack icon, @NotNull String title, @NotNull String description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Util.fromString(title), Util.fromString(description), Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    public AdvancementDisplayWrapper_v1_21_R7(@NotNull ItemStack icon, @NotNull BaseComponent title, @NotNull BaseComponent description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Util.fromComponent(title), Util.fromComponent(description), Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    @Override
+    @NotNull
+    public ItemStack getIcon() {
+        return CraftItemStack.asBukkitCopy(display.getIcon());
+    }
+
+    @Override
+    @NotNull
+    public String getTitle() {
+        return CraftChatMessage.fromComponent(display.getTitle());
+    }
+
+    @Override
+    @NotNull
+    public String getDescription() {
+        return CraftChatMessage.fromComponent(display.getDescription());
+    }
+
+    @Override
+    @NotNull
+    public AdvancementFrameTypeWrapper getAdvancementFrameType() {
+        return frameType;
+    }
+
+    @Override
+    public float getX() {
+        return display.getX();
+    }
+
+    @Override
+    public float getY() {
+        return display.getY();
+    }
+
+    @Override
+    public boolean doesShowToast() {
+        return display.shouldShowToast();
+    }
+
+    @Override
+    public boolean doesAnnounceToChat() {
+        return display.shouldAnnounceChat();
+    }
+
+    @Override
+    public boolean isHidden() {
+        return display.isHidden();
+    }
+
+    @Override
+    @Nullable
+    public String getBackgroundTexture() {
+        Optional<ClientAsset.ResourceTexture> r = display.getBackground();
+        return r.isEmpty() ? null : r.toString();
+    }
+
+    @Override
+    @NotNull
+    public DisplayInfo toNMS() {
+        return display;
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/AdvancementFrameTypeWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/AdvancementFrameTypeWrapper_v1_21_R7.java
@@ -1,0 +1,32 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import org.jetbrains.annotations.NotNull;
+
+public class AdvancementFrameTypeWrapper_v1_21_R7 extends AdvancementFrameTypeWrapper {
+
+    private final net.minecraft.advancements.AdvancementType mcFrameType;
+
+    private final FrameType frameType;
+
+    public AdvancementFrameTypeWrapper_v1_21_R7(@NotNull FrameType frameType) {
+        this.frameType = frameType;
+        this.mcFrameType = switch (frameType) {
+            case TASK -> net.minecraft.advancements.AdvancementType.TASK;
+            case GOAL -> net.minecraft.advancements.AdvancementType.GOAL;
+            case CHALLENGE -> net.minecraft.advancements.AdvancementType.CHALLENGE;
+        };
+    }
+
+    @Override
+    @NotNull
+    public FrameType getFrameType() {
+        return frameType;
+    }
+
+    @Override
+    @NotNull
+    public net.minecraft.advancements.AdvancementType toNMS() {
+        return mcFrameType;
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/AdvancementWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/AdvancementWrapper_v1_21_R7.java
@@ -1,0 +1,88 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AdvancementWrapper_v1_21_R7 extends AdvancementWrapper {
+
+    private final AdvancementHolder advancementHolder;
+    private final MinecraftKeyWrapper key;
+    private final AdvancementWrapper parent;
+    private final AdvancementDisplayWrapper display;
+
+    public AdvancementWrapper_v1_21_R7(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    public AdvancementWrapper_v1_21_R7(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v1_21_R7(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v1_21_R7(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @Nullable
+    public AdvancementWrapper getParent() {
+        return parent;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return this.advancementHolder.value().requirements().size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementHolder toNMS() {
+        return advancementHolder;
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/PreparedAdvancementWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/advancement/PreparedAdvancementWrapper_v1_21_R7.java
@@ -1,0 +1,56 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementWrapper;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+
+public class PreparedAdvancementWrapper_v1_21_R7 extends PreparedAdvancementWrapper {
+
+    private final MinecraftKeyWrapper key;
+    private final AdvancementDisplayWrapper display;
+    private final Map<String, Criterion<?>> advCriteria;
+    private final AdvancementRequirements advRequirements;
+
+    public PreparedAdvancementWrapper_v1_21_R7(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        this.key = key;
+        this.display = display;
+        this.advCriteria = Util.getAdvancementCriteria(maxProgression);
+        this.advRequirements = Util.getAdvancementRequirements(advCriteria);
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return advRequirements.size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toRootAdvancementWrapper() {
+        return new AdvancementWrapper_v1_21_R7(key, display, advCriteria, advRequirements);
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toBaseAdvancementWrapper(@NotNull AdvancementWrapper parent) {
+        return new AdvancementWrapper_v1_21_R7(key, parent, display, advCriteria, advRequirements);
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/packets/PacketPlayOutAdvancementsWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/packets/PacketPlayOutAdvancementsWrapper_v1_21_R7.java
@@ -1,0 +1,49 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.util.ListSet;
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutAdvancementsWrapper;
+import com.google.common.collect.Maps;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class PacketPlayOutAdvancementsWrapper_v1_21_R7 extends PacketPlayOutAdvancementsWrapper {
+
+    private final ClientboundUpdateAdvancementsPacket packet;
+
+    public PacketPlayOutAdvancementsWrapper_v1_21_R7() {
+        this.packet = new ClientboundUpdateAdvancementsPacket(true, Collections.emptyList(), Collections.emptySet(), Collections.emptyMap(), true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v1_21_R7(@NotNull Map<AdvancementWrapper, Integer> toSend) {
+        Map<Identifier, AdvancementProgress> map = Maps.newHashMapWithExpectedSize(toSend.size());
+        for (Entry<AdvancementWrapper, Integer> e : toSend.entrySet()) {
+            AdvancementWrapper adv = e.getKey();
+            map.put((Identifier) adv.getKey().toNMS(), Util.getAdvancementProgress((AdvancementHolder) adv.toNMS(), e.getValue()));
+        }
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, (Collection<AdvancementHolder>) ListSet.fromWrapperSet(toSend.keySet()), Collections.emptySet(), map, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v1_21_R7(@NotNull Set<MinecraftKeyWrapper> toRemove) {
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), (Set<Identifier>) ListSet.fromWrapperSet(toRemove), Collections.emptyMap(), true);
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/packets/PacketPlayOutSelectAdvancementTabWrapper_v1_21_R7.java
+++ b/NMS/1_21_R7/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v1_21_R7/packets/PacketPlayOutSelectAdvancementTabWrapper_v1_21_R7.java
@@ -1,0 +1,27 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v1_21_R7.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutSelectAdvancementTabWrapper;
+import net.minecraft.network.protocol.game.ClientboundSelectAdvancementsTabPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class PacketPlayOutSelectAdvancementTabWrapper_v1_21_R7 extends PacketPlayOutSelectAdvancementTabWrapper {
+
+    private final ClientboundSelectAdvancementsTabPacket packet;
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v1_21_R7() {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) null);
+    }
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v1_21_R7(@NotNull MinecraftKeyWrapper key) {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) key.toNMS());
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-common</artifactId>

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -38,7 +38,8 @@ public class Versions {
             "v1_21_R3",
             "v1_21_R4",
             "v1_21_R5",
-            "v1_21_R6"
+            "v1_21_R6",
+            "v1_21_R7"
     );
 
     private static final Map<String, List<String>> NMS_TO_VERSIONS = Map.ofEntries(
@@ -61,7 +62,8 @@ public class Versions {
             Map.entry("v1_21_R3", List.of("1.21.4")),
             Map.entry("v1_21_R4", List.of("1.21.5")),
             Map.entry("v1_21_R5", List.of("1.21.6", "1.21.7", "1.21.8")),
-            Map.entry("v1_21_R6", List.of("1.21.9", "1.21.10"))
+            Map.entry("v1_21_R6", List.of("1.21.9", "1.21.10")),
+            Map.entry("v1_21_R7", List.of("1.21.11"))
     );
 
     private static final Map<String, String> NMS_TO_FANCY = Map.ofEntries(
@@ -84,7 +86,8 @@ public class Versions {
             Map.entry("v1_21_R3", "1.21.4"),
             Map.entry("v1_21_R4", "1.21.5"),
             Map.entry("v1_21_R5", "1.21.6-1.21.8"),
-            Map.entry("v1_21_R6", "1.21.9-1.21.10")
+            Map.entry("v1_21_R6", "1.21.9-1.21.10"),
+            Map.entry("v1_21_R7", "1.21.11")
     );
 
     private static final List<String> SUPPORTED_VERSIONS = SUPPORTED_NMS_VERSIONS.stream()

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -16,7 +16,7 @@ import java.util.Optional;
  */
 public class Versions {
 
-    private static final String API_VERSION = "2.7.1";
+    private static final String API_VERSION = "2.7.2";
 
     private static final List<String> SUPPORTED_NMS_VERSIONS = List.of(
             "v1_15_R1",

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -136,6 +136,12 @@
             <artifactId>ultimateadvancementapi-nms-1_21_R6</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-distribution</artifactId>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-distribution-mojang-mapped</artifactId>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -152,6 +152,13 @@
             <classifier>mojang-mapped</classifier>
         </dependency>
 
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
+            <version>${project.version}</version>
+            <classifier>mojang-mapped</classifier>
+        </dependency>
+
         <!-- When adding a version remember to add the CraftBukkit relocation below -->
     </dependencies>
 
@@ -189,6 +196,10 @@
                         </relocation>
                         <relocation>
                             <pattern>org.bukkit.craftbukkit.v1_21_R6</pattern>
+                            <shadedPattern>org.bukkit.craftbukkit</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.bukkit.craftbukkit.v1_21_R7</pattern>
                             <shadedPattern>org.bukkit.craftbukkit</shadedPattern>
                         </relocation>
                     </relocations>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-parent</artifactId>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -44,6 +44,7 @@
         <module>1_21_R4</module>
         <module>1_21_R5</module>
         <module>1_21_R6</module>
+        <module>1_21_R7</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
     </modules>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A powerful API to create custom advancements for your minecraft server.
 <dependency>
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <packaging>pom</packaging>
 
     <name>UltimateAdvancementAPI-Parent</name>


### PR DESCRIPTION
* Updated version to 2.7.2
* Updated to Minecraft 1.21.11
* Updated CommandAPI to 11.1.0
* Commands do not fail anymore if an advancement method throws `UnsupportedOperationException`. `UnsupportedOperationException` is thrown when granting or revoking some advancements (like `FakeAdvancement`s), usually when they are not saved in the database. Now, when an `UnsupportedOperationException` is thrown, the advancement is simply ignored instead of failing the command execution
* Refactored commands implementation

Closes #106