### PR TITLE
Add Minecraft 26.1 (Tiny Takeover) support

### DIFF
--- a/NMS/26_1_R1/pom.xml
+++ b/NMS/26_1_R1/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.frengor</groupId>
+        <artifactId>ultimateadvancementapi-nms-parent</artifactId>
+        <version>2.7.2</version>
+    </parent>
+
+    <artifactId>ultimateadvancementapi-nms-26_1_R1</artifactId>
+    <name>UltimateAdvancementAPI-NMS-26_1_R1</name>
+    <url>${parent.url}</url>
+    <packaging>jar</packaging>
+
+    <properties>
+        <mc-version>26.1-R0.1-SNAPSHOT</mc-version>
+    </properties>
+
+    <dependencies>
+        <!-- Spigot API -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spigot (fully unobfuscated since 26.1 - no remapped-mojang classifier needed) -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- NMS Common Module -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>../..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>LGPL</include>
+                    <include>NOTICE</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- No SpecialSource remapping needed: Minecraft 26.1 ships fully unobfuscated -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/MinecraftKeyWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/MinecraftKeyWrapper_v26_1_R1.java
@@ -1,0 +1,46 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import net.minecraft.IdentifierException;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class MinecraftKeyWrapper_v26_1_R1 extends MinecraftKeyWrapper {
+
+    private final Identifier key;
+
+    public MinecraftKeyWrapper_v26_1_R1(@NotNull Object key) {
+        this.key = (Identifier) key;
+    }
+
+    public MinecraftKeyWrapper_v26_1_R1(@NotNull String namespace, @NotNull String key) {
+        try {
+            this.key = Identifier.fromNamespaceAndPath(namespace, key);
+        } catch (IdentifierException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    @Override
+    @NotNull
+    public String getNamespace() {
+        return key.getNamespace();
+    }
+
+    @Override
+    @NotNull
+    public String getKey() {
+        return key.getPath();
+    }
+
+    @Override
+    public int compareTo(@NotNull MinecraftKeyWrapper obj) {
+        return key.compareTo((Identifier) obj.toNMS());
+    }
+
+    @Override
+    @NotNull
+    public Identifier toNMS() {
+        return key;
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/Util.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/Util.java
@@ -1,0 +1,121 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.CriterionProgress;
+import net.minecraft.advancements.criterion.ImpossibleTrigger;
+import net.minecraft.advancements.criterion.ImpossibleTrigger.TriggerInstance;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.resources.Identifier;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class Util {
+
+    public static final Logger ERROR = Logger.getLogger("UltimateAdvancementAPI-NMS");
+
+    @NotNull
+    public static Map<String, Criterion<?>> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
+
+        Map<String, Criterion<?>> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
+        for (int i = 0; i < maxProgression; i++) {
+            advCriteria.put(String.valueOf(i), new Criterion<>(new ImpossibleTrigger(), new TriggerInstance()));
+        }
+
+        return advCriteria;
+    }
+
+    @NotNull
+    public static AdvancementRequirements getAdvancementRequirements(@NotNull Map<String, Criterion<?>> advCriteria) {
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
+
+        List<List<String>> list = new ArrayList<>(advCriteria.size());
+        for (String name : advCriteria.keySet()) {
+            list.add(List.of(name));
+        }
+
+        return new AdvancementRequirements(list);
+    }
+
+    @NotNull
+    public static AdvancementProgress getAdvancementProgress(@NotNull AdvancementHolder mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
+
+        AdvancementProgress advPrg = new AdvancementProgress();
+        advPrg.update(mcAdv.value().requirements());
+
+        for (int i = 0; i < progression; i++) {
+            CriterionProgress criteriaPrg = advPrg.getCriterion(String.valueOf(i));
+            if (criteriaPrg != null) {
+                criteriaPrg.grant();
+            }
+        }
+
+        return advPrg;
+    }
+
+    @NotNull
+    public static Component fromString(@NotNull String string) {
+        if (string == null || string.isEmpty()) {
+            return CommonComponents.EMPTY;
+        }
+        return CraftChatMessage.fromStringOrNull(string, true);
+    }
+
+    @NotNull
+    public static Component fromComponent(@NotNull BaseComponent component) {
+        if (component == null) {
+            return CommonComponents.EMPTY;
+        }
+        Component base = CraftChatMessage.fromJSONOrNull(ComponentSerializer.toString(component));
+        return base == null ? CommonComponents.EMPTY : base;
+    }
+
+    @Nullable
+    public static ClientAsset.ResourceTexture parseBackgroundTexture(@Nullable String backgroundTexture) {
+        if (backgroundTexture == null) {
+            return null;
+        }
+
+        Identifier texturePath = Identifier.parse(backgroundTexture);
+        if (!texturePath.getPath().startsWith("textures/") || !texturePath.getPath().endsWith(".png")) {
+            ERROR.severe("Invalid background texture \"" + backgroundTexture + "\" (the path should be in the form \"textures/**.png\")");
+            return null;
+        }
+
+        Identifier id = texturePath.withPath(path -> {
+            return path.substring("textures/".length(), path.length() - ".png".length());
+        });
+        return new ClientAsset.ResourceTexture(id, texturePath);
+    }
+
+    public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
+        ((CraftPlayer) player).getHandle().connection.send(packet);
+    }
+
+    private Util() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/VanillaAdvancementDisablerWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/VanillaAdvancementDisablerWrapper_v26_1_R1.java
@@ -1,0 +1,184 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.VanillaAdvancementDisablerWrapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementNode;
+import net.minecraft.advancements.AdvancementTree;
+import net.minecraft.advancements.AdvancementTree.Listener;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.ServerAdvancementManager;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.simple.SimpleLogger;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class VanillaAdvancementDisablerWrapper_v26_1_R1 extends VanillaAdvancementDisablerWrapper {
+
+    private static Logger LOGGER = null;
+    private static Field listener, firstPacket;
+
+    static {
+        try {
+            listener = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == AdvancementTree.Listener.class).findFirst().orElseThrow();
+            listener.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            firstPacket = Arrays.stream(PlayerAdvancements.class.getDeclaredFields()).filter(f -> f.getType() == boolean.class).findFirst().orElseThrow();
+            firstPacket.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Field logger = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == org.slf4j.Logger.class).findFirst().orElseThrow();
+            logger.setAccessible(true);
+            org.slf4j.Logger slf4jLogger = (org.slf4j.Logger) logger.get(null);
+            LOGGER = Arrays.stream(slf4jLogger.getClass().getDeclaredFields()).filter(f -> !Modifier.isStatic(f.getModifiers())).map(f -> {
+                try {
+                    f.setAccessible(true);
+                    if (f.get(slf4jLogger) instanceof Logger log) {
+                        return log;
+                    }
+                } catch (ReflectiveOperationException e) {
+                    e.printStackTrace();
+                }
+                return null;
+            }).filter(Objects::nonNull).findFirst().orElseThrow();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void disableVanillaAdvancements(boolean vanillaAdvancements, boolean vanillaRecipeAdvancements) throws Exception {
+        ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
+        AdvancementTree tree = serverAdvancements.tree();
+
+        if (serverAdvancements.advancements.isEmpty()) {
+            return;
+        }
+
+        final Set<Identifier> removed = Sets.newHashSetWithExpectedSize(serverAdvancements.advancements.size());
+
+        // Inject AdvancementTree listener
+        final Listener old = (Listener) listener.get(tree);
+        try {
+            listener.set(tree, new Listener() {
+                @Override
+                public void onAddAdvancementRoot(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementRoot(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onAddAdvancementTask(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementTask(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onAdvancementsCleared() {
+                    if (old != null)
+                        old.onAdvancementsCleared();
+                }
+            });
+
+            Set<Identifier> locations = new HashSet<>();
+            ImmutableMap.Builder<Identifier, AdvancementHolder> builder = ImmutableMap.builder();
+            for (var entry : serverAdvancements.advancements.entrySet()) {
+                Identifier key = entry.getKey();
+                boolean isRecipe = key.getPath().startsWith("recipes/");
+                if (key.getNamespace().equals("minecraft") && ((vanillaAdvancements && !isRecipe) || (vanillaRecipeAdvancements && isRecipe))) {
+                    locations.add(key);
+                } else {
+                    builder.put(key, entry.getValue());
+                }
+            }
+
+            serverAdvancements.advancements = builder.buildOrThrow();
+
+            final Level oldLevel = disableLogger();
+            try {
+                tree.remove(locations);
+            } finally {
+                // Always restore old logger
+                enableLogger(oldLevel);
+            }
+        } finally {
+            // Always uninject advancement listener
+            listener.set(tree, old);
+        }
+
+        final var removePacket = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), removed, Collections.emptyMap(), false);
+
+        // Remove advancements from players
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            var mcPlayer = ((CraftPlayer) player).getHandle();
+            var advs = mcPlayer.getAdvancements();
+            advs.reload(serverAdvancements);
+            firstPacket.setBoolean(advs, false); // Don't clear every client advancement
+            mcPlayer.connection.send(removePacket);
+        }
+    }
+
+    private static Level disableLogger() {
+        if (LOGGER == null) // Fail-safe if LOGGER could not be found by reflections
+            return null;
+
+        Level old = LOGGER.getLevel();
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(Level.OFF);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(Level.OFF);
+        }
+
+        return old;
+    }
+
+    private static void enableLogger(Level toSet) {
+        if (LOGGER == null || toSet == null) // Fail-safe if LOGGER could not be found by reflections
+            return;
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(toSet);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(toSet);
+        }
+    }
+
+    private VanillaAdvancementDisablerWrapper_v26_1_R1() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/AdvancementDisplayWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/AdvancementDisplayWrapper_v26_1_R1.java
@@ -1,0 +1,98 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.advancements.AdvancementType;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.core.ClientAsset;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class AdvancementDisplayWrapper_v26_1_R1 extends AdvancementDisplayWrapper {
+
+    private final DisplayInfo display;
+    private final AdvancementFrameTypeWrapper frameType;
+
+    public AdvancementDisplayWrapper_v26_1_R1(@NotNull ItemStack icon, @NotNull String title, @NotNull String description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Util.fromString(title), Util.fromString(description), Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    public AdvancementDisplayWrapper_v26_1_R1(@NotNull ItemStack icon, @NotNull BaseComponent title, @NotNull BaseComponent description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(CraftItemStack.asNMSCopy(icon), Util.fromComponent(title), Util.fromComponent(description), Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    @Override
+    @NotNull
+    public ItemStack getIcon() {
+        return CraftItemStack.asBukkitCopy(display.getIcon());
+    }
+
+    @Override
+    @NotNull
+    public String getTitle() {
+        return CraftChatMessage.fromComponent(display.getTitle());
+    }
+
+    @Override
+    @NotNull
+    public String getDescription() {
+        return CraftChatMessage.fromComponent(display.getDescription());
+    }
+
+    @Override
+    @NotNull
+    public AdvancementFrameTypeWrapper getAdvancementFrameType() {
+        return frameType;
+    }
+
+    @Override
+    public float getX() {
+        return display.getX();
+    }
+
+    @Override
+    public float getY() {
+        return display.getY();
+    }
+
+    @Override
+    public boolean doesShowToast() {
+        return display.shouldShowToast();
+    }
+
+    @Override
+    public boolean doesAnnounceToChat() {
+        return display.shouldAnnounceChat();
+    }
+
+    @Override
+    public boolean isHidden() {
+        return display.isHidden();
+    }
+
+    @Override
+    @Nullable
+    public String getBackgroundTexture() {
+        Optional<ClientAsset.ResourceTexture> r = display.getBackground();
+        return r.isEmpty() ? null : r.toString();
+    }
+
+    @Override
+    @NotNull
+    public DisplayInfo toNMS() {
+        return display;
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/AdvancementFrameTypeWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/AdvancementFrameTypeWrapper_v26_1_R1.java
@@ -1,0 +1,32 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import org.jetbrains.annotations.NotNull;
+
+public class AdvancementFrameTypeWrapper_v26_1_R1 extends AdvancementFrameTypeWrapper {
+
+    private final net.minecraft.advancements.AdvancementType mcFrameType;
+
+    private final FrameType frameType;
+
+    public AdvancementFrameTypeWrapper_v26_1_R1(@NotNull FrameType frameType) {
+        this.frameType = frameType;
+        this.mcFrameType = switch (frameType) {
+            case TASK -> net.minecraft.advancements.AdvancementType.TASK;
+            case GOAL -> net.minecraft.advancements.AdvancementType.GOAL;
+            case CHALLENGE -> net.minecraft.advancements.AdvancementType.CHALLENGE;
+        };
+    }
+
+    @Override
+    @NotNull
+    public FrameType getFrameType() {
+        return frameType;
+    }
+
+    @Override
+    @NotNull
+    public net.minecraft.advancements.AdvancementType toNMS() {
+        return mcFrameType;
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/AdvancementWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/AdvancementWrapper_v26_1_R1.java
@@ -1,0 +1,88 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AdvancementWrapper_v26_1_R1 extends AdvancementWrapper {
+
+    private final AdvancementHolder advancementHolder;
+    private final MinecraftKeyWrapper key;
+    private final AdvancementWrapper parent;
+    private final AdvancementDisplayWrapper display;
+
+    public AdvancementWrapper_v26_1_R1(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    public AdvancementWrapper_v26_1_R1(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v26_1_R1(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v26_1_R1(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @Nullable
+    public AdvancementWrapper getParent() {
+        return parent;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return this.advancementHolder.value().requirements().size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementHolder toNMS() {
+        return advancementHolder;
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/PreparedAdvancementWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/advancement/PreparedAdvancementWrapper_v26_1_R1.java
@@ -1,0 +1,56 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementWrapper;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+
+public class PreparedAdvancementWrapper_v26_1_R1 extends PreparedAdvancementWrapper {
+
+    private final MinecraftKeyWrapper key;
+    private final AdvancementDisplayWrapper display;
+    private final Map<String, Criterion<?>> advCriteria;
+    private final AdvancementRequirements advRequirements;
+
+    public PreparedAdvancementWrapper_v26_1_R1(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        this.key = key;
+        this.display = display;
+        this.advCriteria = Util.getAdvancementCriteria(maxProgression);
+        this.advRequirements = Util.getAdvancementRequirements(advCriteria);
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return advRequirements.size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toRootAdvancementWrapper() {
+        return new AdvancementWrapper_v26_1_R1(key, display, advCriteria, advRequirements);
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toBaseAdvancementWrapper(@NotNull AdvancementWrapper parent) {
+        return new AdvancementWrapper_v26_1_R1(key, parent, display, advCriteria, advRequirements);
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/packets/PacketPlayOutAdvancementsWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/packets/PacketPlayOutAdvancementsWrapper_v26_1_R1.java
@@ -1,0 +1,49 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.util.ListSet;
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutAdvancementsWrapper;
+import com.google.common.collect.Maps;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class PacketPlayOutAdvancementsWrapper_v26_1_R1 extends PacketPlayOutAdvancementsWrapper {
+
+    private final ClientboundUpdateAdvancementsPacket packet;
+
+    public PacketPlayOutAdvancementsWrapper_v26_1_R1() {
+        this.packet = new ClientboundUpdateAdvancementsPacket(true, Collections.emptyList(), Collections.emptySet(), Collections.emptyMap(), true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v26_1_R1(@NotNull Map<AdvancementWrapper, Integer> toSend) {
+        Map<Identifier, AdvancementProgress> map = Maps.newHashMapWithExpectedSize(toSend.size());
+        for (Entry<AdvancementWrapper, Integer> e : toSend.entrySet()) {
+            AdvancementWrapper adv = e.getKey();
+            map.put((Identifier) adv.getKey().toNMS(), Util.getAdvancementProgress((AdvancementHolder) adv.toNMS(), e.getValue()));
+        }
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, (Collection<AdvancementHolder>) ListSet.fromWrapperSet(toSend.keySet()), Collections.emptySet(), map, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v26_1_R1(@NotNull Set<MinecraftKeyWrapper> toRemove) {
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), (Set<Identifier>) ListSet.fromWrapperSet(toRemove), Collections.emptyMap(), true);
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/packets/PacketPlayOutSelectAdvancementTabWrapper_v26_1_R1.java
+++ b/NMS/26_1_R1/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R1/packets/PacketPlayOutSelectAdvancementTabWrapper_v26_1_R1.java
@@ -1,0 +1,27 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R1.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutSelectAdvancementTabWrapper;
+import net.minecraft.network.protocol.game.ClientboundSelectAdvancementsTabPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class PacketPlayOutSelectAdvancementTabWrapper_v26_1_R1 extends PacketPlayOutSelectAdvancementTabWrapper {
+
+    private final ClientboundSelectAdvancementsTabPacket packet;
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v26_1_R1() {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) null);
+    }
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v26_1_R1(@NotNull MinecraftKeyWrapper key) {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) key.toNMS());
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ReflectionUtil.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ReflectionUtil.java
@@ -15,13 +15,13 @@ public class ReflectionUtil {
 
     /**
      * The Minecraft version.
-     * <p>For example {@code 1.17.1}.
+     * <p>For example {@code 1.17.1} or {@code 26.1} (new year-based scheme introduced in 26.1).
      */
     public static final String MINECRAFT_VERSION = Bukkit.getBukkitVersion().split("-")[0];
 
     /**
      * The Minecraft minor version.
-     * <p>For example, for {@code 1.19.2} it is {@code 2}.
+     * <p>For example, for {@code 1.19.2} it is {@code 2}. For new-format versions like {@code 26.1} it is {@code 0}.
      */
     public static final int MINOR_VERSION;
 
@@ -36,13 +36,19 @@ public class ReflectionUtil {
 
     private static final String CRAFTBUKKIT_PACKAGE = Bukkit.getServer().getClass().getPackage().getName();
 
+    // First segment of the version string: "1" for old format (1.x.y), year for new format (26.1)
+    private static final int MAJOR_SEGMENT = Integer.parseInt(MINECRAFT_VERSION.split("\\.")[0]);
+
     /**
      * The NMS version.
-     * <p>For example, for {@code v1_17_R1} it is {@code 17}.
+     * <p>For old-format versions (1.x.y), this is the major release number (e.g., {@code 21} for 1.21.x).
+     * For new year-based versions (e.g., {@code 26.1}), this is the drop number (e.g., {@code 1}).
      */
     public static final int VERSION = Integer.parseInt(MINECRAFT_VERSION.split("\\.")[1]);
 
-    private static final boolean IS_1_17 = VERSION >= 17;
+    // True if the server uses Mojang-mapped class names (net.minecraft.xxx) rather than net.minecraft.server.vX_Y_RZ.
+    // All new year-based versions (26.x+) and old 1.17+ versions use Mojang mappings.
+    private static final boolean IS_1_17 = MAJOR_SEGMENT > 1 || VERSION >= 17;
 
     /**
      * Returns whether the provided class exists.

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -39,7 +39,8 @@ public class Versions {
             "v1_21_R4",
             "v1_21_R5",
             "v1_21_R6",
-            "v1_21_R7"
+            "v1_21_R7",
+            "v26_1_R1"
     );
 
     private static final Map<String, List<String>> NMS_TO_VERSIONS = Map.ofEntries(
@@ -63,7 +64,8 @@ public class Versions {
             Map.entry("v1_21_R4", List.of("1.21.5")),
             Map.entry("v1_21_R5", List.of("1.21.6", "1.21.7", "1.21.8")),
             Map.entry("v1_21_R6", List.of("1.21.9", "1.21.10")),
-            Map.entry("v1_21_R7", List.of("1.21.11"))
+            Map.entry("v1_21_R7", List.of("1.21.11")),
+            Map.entry("v26_1_R1", List.of("26.1", "26.1.1"))
     );
 
     private static final Map<String, String> NMS_TO_FANCY = Map.ofEntries(
@@ -87,7 +89,8 @@ public class Versions {
             Map.entry("v1_21_R4", "1.21.5"),
             Map.entry("v1_21_R5", "1.21.6-1.21.8"),
             Map.entry("v1_21_R6", "1.21.9-1.21.10"),
-            Map.entry("v1_21_R7", "1.21.11")
+            Map.entry("v1_21_R7", "1.21.11"),
+            Map.entry("v26_1_R1", "26.1-26.1.1")
     );
 
     private static final List<String> SUPPORTED_VERSIONS = SUPPORTED_NMS_VERSIONS.stream()

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-26_1_R1</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -159,6 +159,13 @@
             <classifier>mojang-mapped</classifier>
         </dependency>
 
+        <!-- 26.1 ships fully unobfuscated; no mojang-mapped classifier needed -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-26_1_R1</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- When adding a version remember to add the CraftBukkit relocation below -->
     </dependencies>
 

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -45,6 +45,7 @@
         <module>1_21_R5</module>
         <module>1_21_R6</module>
         <module>1_21_R7</module>
+        <module>26_1_R1</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
     </modules>


### PR DESCRIPTION
- Add NMS/26_1_R1 module with all wrapper implementations
- No SpecialSource remapping 
- CraftBukkit imports use unversioned package (org.bukkit.craftbukkit.X)
- Fix ReflectionUtil.IS_1_17 to handle new year-based versioning (26.x)
- Register v26_1_R1 in Versions.java mapping 26.1 and 26.1.1
- Add 26_1_R1 to NMS parent, Distribution and DistributionMojangMapped poms