### PR TITLE
Update to 2.8.0

### DIFF
--- a/Commands/CommandAPI-10.1.2/pom.xml
+++ b/Commands/CommandAPI-10.1.2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-10.1.2</artifactId>

--- a/Commands/CommandAPI-11.2.0/pom.xml
+++ b/Commands/CommandAPI-11.2.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>

--- a/Commands/CommandAPI-11.2.0/pom.xml
+++ b/Commands/CommandAPI-11.2.0/pom.xml
@@ -10,8 +10,8 @@
         <version>2.7.2</version>
     </parent>
 
-    <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
-    <name>UltimateAdvancementAPI-Commands-CommandAPI-11.1.0</name>
+    <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>
+    <name>UltimateAdvancementAPI-Commands-CommandAPI-11.2.0</name>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-spigot-core</artifactId>
-            <version>11.1.0</version>
+            <version>11.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementArgument.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementTabArgument.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementTabArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/CommandAPIManager.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/CommandAPIManager.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/UltimateAdvancementAPICommand.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0.AdvancementArgument.getAdvancementArgument;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0.AdvancementTabArgument.getAdvancementTabArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0.AdvancementArgument.getAdvancementArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0.AdvancementTabArgument.getAdvancementTabArgument;
 
 public class UltimateAdvancementAPICommand {
 

--- a/Commands/CommandAPI-9.3.0/pom.xml
+++ b/Commands/CommandAPI-9.3.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9.3.0</artifactId>

--- a/Commands/CommandAPI-9.7.0/pom.xml
+++ b/Commands/CommandAPI-9.7.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9.7.0</artifactId>

--- a/Commands/Common/pom.xml
+++ b/Commands/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-common</artifactId>

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
@@ -59,16 +59,17 @@ public enum CommandAPIVersion {
                     "v1_21_R4"
             )
     ),
-    LATEST("11.1.0",
+    LATEST("11.2.0",
             "commandapi-spigot-shade",
             "commandapi-paper-shade",
-            "E0rUSMwJKIHP5skpdscHMhq4VslVNnfcxh4QnY8N2Vw=",
-            "WG0DkQHBm8me54fVf5e3lVY+50qwvvOFhApxT+na+Ho=",
-            "11_1_0",
+            "Kx6c7DPWPyFkrmlEYq1hj6VeQm4BbBBMbthKI1pHLes=",
+            "F6KljlYn01+rt6JIKJPOKmWI++d46LgeOd8e6dw6gIM=",
+            "11_2_0",
             List.of(
                     "v1_21_R5",
                     "v1_21_R6",
-                    "v1_21_R7"
+                    "v1_21_R7",
+                    "v26_1_R2"
             )
     );
 

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-distribution</artifactId>

--- a/Commands/Distribution/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/MojangMappingsHandler.java
+++ b/Commands/Distribution/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/MojangMappingsHandler.java
@@ -16,7 +16,7 @@ public final class MojangMappingsHandler {
      */
     public static boolean isMojangMapped() {
         // Load the Mojang mapped CommandAPI on Paper 1.20.6+ as a workaround for https://github.com/PaperMC/Paper/issues/10713
-        return IS_PAPER && (ReflectionUtil.VERSION > 20 || (ReflectionUtil.VERSION == 20 && ReflectionUtil.MINOR_VERSION >= 6));
+        return IS_PAPER && (ReflectionUtil.MAJOR_VERSION >= 26 || (ReflectionUtil.MAJOR_VERSION == 1 && (ReflectionUtil.VERSION > 20 || (ReflectionUtil.VERSION == 20 && ReflectionUtil.MINOR_VERSION >= 6))));
     }
 
     private MojangMappingsHandler() {

--- a/Commands/DistributionMojangMapped/pom.xml
+++ b/Commands/DistributionMojangMapped/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/DistributionMojangMapped/pom.xml
+++ b/Commands/DistributionMojangMapped/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-distribution-mojang-mapped</artifactId>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>ultimateadvancementapi-parent</artifactId>
         <groupId>com.frengor</groupId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-parent</artifactId>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -25,7 +25,7 @@
         <module>CommandAPI-9.3.0</module>
         <module>CommandAPI-9.7.0</module>
         <module>CommandAPI-10.1.2</module>
-        <module>CommandAPI-11.1.0</module>
+        <module>CommandAPI-11.2.0</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
     </modules>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-common</artifactId>

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
@@ -235,7 +235,7 @@ public final class DatabaseManager {
         database.setUp();
 
         // Don't use PlayerLoginEvent on Paper 1.21.7+
-        if (IS_PAPER && (ReflectionUtil.VERSION > 21 || (ReflectionUtil.VERSION == 21 && ReflectionUtil.MINOR_VERSION >= 7))) {
+        if (IS_PAPER && (ReflectionUtil.MAJOR_VERSION >= 26 || (ReflectionUtil.MAJOR_VERSION == 1 && (ReflectionUtil.VERSION > 21 || (ReflectionUtil.VERSION == 21 && ReflectionUtil.MINOR_VERSION >= 7))))) {
             // Must use reflections since we're compiling using the Spigot artifact
             Class<? extends Event> playerConnectionInitialConfigureEventClass, playerConnectionCloseEventClass;
             Method getConnection, getProfile, getId, getName, getPlayerUniqueId;

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/nms/mocked1_17_R1/MinecraftKeyWrapper_mocked1_17_R1.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/nms/mocked1_17_R1/MinecraftKeyWrapper_mocked1_17_R1.java
@@ -1,19 +1,19 @@
-package com.fren_gor.ultimateAdvancementAPI.nms.serverVersion1_17_R1;
+package com.fren_gor.ultimateAdvancementAPI.nms.mocked1_17_R1;
 
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
 import com.fren_gor.ultimateAdvancementAPI.util.AdvancementKey;
 import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
-public class MinecraftKeyWrapper_serverVersion1_17_R1 extends MinecraftKeyWrapper {
+public class MinecraftKeyWrapper_mocked1_17_R1 extends MinecraftKeyWrapper {
 
     private final String namespace, key;
 
-    public MinecraftKeyWrapper_serverVersion1_17_R1(@NotNull Object key) {
+    public MinecraftKeyWrapper_mocked1_17_R1(@NotNull Object key) {
         throw new UnsupportedOperationException();
     }
 
-    public MinecraftKeyWrapper_serverVersion1_17_R1(@NotNull String namespace, @NotNull String key) {
+    public MinecraftKeyWrapper_mocked1_17_R1(@NotNull String namespace, @NotNull String key) {
         AdvancementKey.checkNamespace(namespace);
         AdvancementKey.checkKey(key);
         Preconditions.checkArgument(AdvancementKey.VALID_NAMESPACE.matcher(namespace).matches());

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/nms/mocked1_17_R1/advancement/AdvancementFrameTypeWrapper_mocked1_17_R1.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/nms/mocked1_17_R1/advancement/AdvancementFrameTypeWrapper_mocked1_17_R1.java
@@ -1,14 +1,14 @@
-package com.fren_gor.ultimateAdvancementAPI.nms.serverVersion1_17_R1.advancement;
+package com.fren_gor.ultimateAdvancementAPI.nms.mocked1_17_R1.advancement;
 
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
 import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
 import org.jetbrains.annotations.NotNull;
 
-public class AdvancementFrameTypeWrapper_serverVersion1_17_R1 extends AdvancementFrameTypeWrapper {
+public class AdvancementFrameTypeWrapper_mocked1_17_R1 extends AdvancementFrameTypeWrapper {
 
     private final FrameType frameType;
 
-    public AdvancementFrameTypeWrapper_serverVersion1_17_R1(@NotNull FrameType frameType) {
+    public AdvancementFrameTypeWrapper_mocked1_17_R1(@NotNull FrameType frameType) {
         this.frameType = frameType;
     }
 

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/Utils.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/Utils.java
@@ -89,7 +89,7 @@ public final class Utils {
         try {
             Field f = Versions.class.getDeclaredField("COMPLETE_VERSION");
             f.setAccessible(true);
-            f.set(null, Optional.of("serverVersion1_17_R1"));
+            f.set(null, Optional.of("mocked1_17_R1"));
 
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
@@ -98,7 +98,7 @@ public final class Utils {
         MockedStatic<Bukkit> bukkitMock = Mockito.mockStatic(Bukkit.class);
         Server server = InterfaceImplementer.newFakeServer();
         bukkitMock.when(Bukkit::getServer).thenReturn(server);
-        bukkitMock.when(Bukkit::getBukkitVersion).thenReturn("serverVersion1.17.1-R0.1-SNAPSHOT");
+        bukkitMock.when(Bukkit::getBukkitVersion).thenReturn("1.17.1-mocked-R0.1-SNAPSHOT");
         assertSame("Server mock failed", Bukkit.getServer(), server);
         PluginManager plManager = new SimplePluginManager(server, new SimpleCommandMap(server));
         bukkitMock.when(Bukkit::getPluginManager).thenReturn(plManager);

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/VersionsTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/VersionsTest.java
@@ -32,7 +32,7 @@ public class VersionsTest {
 
     @Test
     public void getNMSVersionTest() {
-        Utils.mockServer(() -> assertEquals("serverVersion1_17_R1", Versions.getNMSVersion().get()));
+        Utils.mockServer(() -> assertEquals("mocked1_17_R1", Versions.getNMSVersion().get()));
     }
 
     @Test

--- a/Distribution/API/pom.xml
+++ b/Distribution/API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi</artifactId>

--- a/Distribution/Commands/pom.xml
+++ b/Distribution/Commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands</artifactId>

--- a/Distribution/Shadeable/pom.xml
+++ b/Distribution/Shadeable/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-shadeable</artifactId>

--- a/Distribution/pom.xml
+++ b/Distribution/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <!-- (optionally) overridden by modules -->
         <javadocArtifactId>ultimateadvancementapi-common</javadocArtifactId>
-        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped.jar</mojangMappedJarFile>
+        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped-Legacy.jar</mojangMappedJarFile>
         <artifactIdToExclude>overridden-by-modules</artifactIdToExclude>
     </properties>
 
@@ -155,7 +155,7 @@
                                     <artifact>
                                         <file>${mojangMappedJarFile}</file>
                                         <type>jar</type>
-                                        <classifier>mojang-mapped</classifier>
+                                        <classifier>mojang-mapped-legacy</classifier>
                                     </artifact>
                                 </artifacts>
                             </configuration>

--- a/Distribution/pom.xml
+++ b/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-distribution</artifactId>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     }
     tools {
         maven 'Maven'
-        jdk 'jdk21'
+        jdk 'jdk25'
     }
 
     stages {

--- a/NMS/1_15_R1/pom.xml
+++ b/NMS/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_15_R1</artifactId>

--- a/NMS/1_16_R1/pom.xml
+++ b/NMS/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R1</artifactId>

--- a/NMS/1_16_R2/pom.xml
+++ b/NMS/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R2</artifactId>

--- a/NMS/1_16_R3/pom.xml
+++ b/NMS/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R3</artifactId>

--- a/NMS/1_17_R1/pom.xml
+++ b/NMS/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_17_R1</artifactId>

--- a/NMS/1_18_R1/pom.xml
+++ b/NMS/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>

--- a/NMS/1_18_R2/pom.xml
+++ b/NMS/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>

--- a/NMS/1_19_R1/pom.xml
+++ b/NMS/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>

--- a/NMS/1_19_R2/pom.xml
+++ b/NMS/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>

--- a/NMS/1_19_R3/pom.xml
+++ b/NMS/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>

--- a/NMS/1_20_R1/pom.xml
+++ b/NMS/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>

--- a/NMS/1_20_R2/pom.xml
+++ b/NMS/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R2</artifactId>

--- a/NMS/1_20_R3/pom.xml
+++ b/NMS/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R3</artifactId>

--- a/NMS/1_20_R4/pom.xml
+++ b/NMS/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R4</artifactId>

--- a/NMS/1_21_R1/pom.xml
+++ b/NMS/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R1</artifactId>

--- a/NMS/1_21_R2/pom.xml
+++ b/NMS/1_21_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R2</artifactId>

--- a/NMS/1_21_R3/pom.xml
+++ b/NMS/1_21_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R3</artifactId>

--- a/NMS/1_21_R4/pom.xml
+++ b/NMS/1_21_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R4</artifactId>

--- a/NMS/1_21_R5/pom.xml
+++ b/NMS/1_21_R5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R5</artifactId>

--- a/NMS/1_21_R6/pom.xml
+++ b/NMS/1_21_R6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R6</artifactId>

--- a/NMS/1_21_R7/pom.xml
+++ b/NMS/1_21_R7/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>

--- a/NMS/26_1_R2/pom.xml
+++ b/NMS/26_1_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>

--- a/NMS/26_1_R2/pom.xml
+++ b/NMS/26_1_R2/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.frengor</groupId>
+        <artifactId>ultimateadvancementapi-nms-parent</artifactId>
+        <version>2.7.2</version>
+    </parent>
+
+    <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>
+    <name>UltimateAdvancementAPI-NMS-26_1_R2</name>
+    <url>${parent.url}</url>
+    <packaging>jar</packaging>
+
+    <properties>
+        <mc-version>26.1.2-R0.1-SNAPSHOT</mc-version>
+    </properties>
+
+    <dependencies>
+        <!-- Spigot API -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spigot -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- NMS Common Module -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>../..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>LGPL</include>
+                    <include>NOTICE</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/MinecraftKeyWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/MinecraftKeyWrapper_v26_1_R2.java
@@ -1,0 +1,46 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import net.minecraft.IdentifierException;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class MinecraftKeyWrapper_v26_1_R2 extends MinecraftKeyWrapper {
+
+    private final Identifier key;
+
+    public MinecraftKeyWrapper_v26_1_R2(@NotNull Object key) {
+        this.key = (Identifier) key;
+    }
+
+    public MinecraftKeyWrapper_v26_1_R2(@NotNull String namespace, @NotNull String key) {
+        try {
+            this.key = Identifier.fromNamespaceAndPath(namespace, key);
+        } catch (IdentifierException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    @Override
+    @NotNull
+    public String getNamespace() {
+        return key.getNamespace();
+    }
+
+    @Override
+    @NotNull
+    public String getKey() {
+        return key.getPath();
+    }
+
+    @Override
+    public int compareTo(@NotNull MinecraftKeyWrapper obj) {
+        return key.compareTo((Identifier) obj.toNMS());
+    }
+
+    @Override
+    @NotNull
+    public Identifier toNMS() {
+        return key;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/Util.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/Util.java
@@ -1,0 +1,121 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.CriterionProgress;
+import net.minecraft.advancements.criterion.ImpossibleTrigger;
+import net.minecraft.advancements.criterion.ImpossibleTrigger.TriggerInstance;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.resources.Identifier;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class Util {
+
+    public static final Logger ERROR = Logger.getLogger("UltimateAdvancementAPI-NMS");
+
+    @NotNull
+    public static Map<String, Criterion<?>> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
+
+        Map<String, Criterion<?>> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
+        for (int i = 0; i < maxProgression; i++) {
+            advCriteria.put(String.valueOf(i), new Criterion<>(new ImpossibleTrigger(), new TriggerInstance()));
+        }
+
+        return advCriteria;
+    }
+
+    @NotNull
+    public static AdvancementRequirements getAdvancementRequirements(@NotNull Map<String, Criterion<?>> advCriteria) {
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
+
+        List<List<String>> list = new ArrayList<>(advCriteria.size());
+        for (String name : advCriteria.keySet()) {
+            list.add(List.of(name));
+        }
+
+        return new AdvancementRequirements(list);
+    }
+
+    @NotNull
+    public static AdvancementProgress getAdvancementProgress(@NotNull AdvancementHolder mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
+
+        AdvancementProgress advPrg = new AdvancementProgress();
+        advPrg.update(mcAdv.value().requirements());
+
+        for (int i = 0; i < progression; i++) {
+            CriterionProgress criteriaPrg = advPrg.getCriterion(String.valueOf(i));
+            if (criteriaPrg != null) {
+                criteriaPrg.grant();
+            }
+        }
+
+        return advPrg;
+    }
+
+    @NotNull
+    public static Component fromString(@NotNull String string) {
+        if (string == null || string.isEmpty()) {
+            return CommonComponents.EMPTY;
+        }
+        return CraftChatMessage.fromStringOrNull(string, true);
+    }
+
+    @NotNull
+    public static Component fromComponent(@NotNull BaseComponent component) {
+        if (component == null) {
+            return CommonComponents.EMPTY;
+        }
+        Component base = CraftChatMessage.fromJSONOrNull(ComponentSerializer.toString(component));
+        return base == null ? CommonComponents.EMPTY : base;
+    }
+
+    @Nullable
+    public static ClientAsset.ResourceTexture parseBackgroundTexture(@Nullable String backgroundTexture) {
+        if (backgroundTexture == null) {
+            return null;
+        }
+
+        Identifier texturePath = Identifier.parse(backgroundTexture);
+        if (!texturePath.getPath().startsWith("textures/") || !texturePath.getPath().endsWith(".png")) {
+            ERROR.severe("Invalid background texture \"" + backgroundTexture + "\" (the path should be in the form \"textures/**.png\")");
+            return null;
+        }
+
+        Identifier id = texturePath.withPath(path -> {
+            return path.substring("textures/".length(), path.length() - ".png".length());
+        });
+        return new ClientAsset.ResourceTexture(id, texturePath);
+    }
+
+    public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
+        ((CraftPlayer) player).getHandle().connection.send(packet);
+    }
+
+    private Util() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/VanillaAdvancementDisablerWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/VanillaAdvancementDisablerWrapper_v26_1_R2.java
@@ -1,0 +1,184 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.VanillaAdvancementDisablerWrapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementNode;
+import net.minecraft.advancements.AdvancementTree;
+import net.minecraft.advancements.AdvancementTree.Listener;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.ServerAdvancementManager;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.simple.SimpleLogger;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class VanillaAdvancementDisablerWrapper_v26_1_R2 extends VanillaAdvancementDisablerWrapper {
+
+    private static Logger LOGGER = null;
+    private static Field listener, firstPacket;
+
+    static {
+        try {
+            listener = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == AdvancementTree.Listener.class).findFirst().orElseThrow();
+            listener.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            firstPacket = Arrays.stream(PlayerAdvancements.class.getDeclaredFields()).filter(f -> f.getType() == boolean.class).findFirst().orElseThrow();
+            firstPacket.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Field logger = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == org.slf4j.Logger.class).findFirst().orElseThrow();
+            logger.setAccessible(true);
+            org.slf4j.Logger slf4jLogger = (org.slf4j.Logger) logger.get(null);
+            LOGGER = Arrays.stream(slf4jLogger.getClass().getDeclaredFields()).filter(f -> !Modifier.isStatic(f.getModifiers())).map(f -> {
+                try {
+                    f.setAccessible(true);
+                    if (f.get(slf4jLogger) instanceof Logger log) {
+                        return log;
+                    }
+                } catch (ReflectiveOperationException e) {
+                    e.printStackTrace();
+                }
+                return null;
+            }).filter(Objects::nonNull).findFirst().orElseThrow();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void disableVanillaAdvancements(boolean vanillaAdvancements, boolean vanillaRecipeAdvancements) throws Exception {
+        ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
+        AdvancementTree tree = serverAdvancements.tree();
+
+        if (serverAdvancements.advancements.isEmpty()) {
+            return;
+        }
+
+        final Set<Identifier> removed = Sets.newHashSetWithExpectedSize(serverAdvancements.advancements.size());
+
+        // Inject AdvancementTree listener
+        final Listener old = (Listener) listener.get(tree);
+        try {
+            listener.set(tree, new Listener() {
+                @Override
+                public void onAddAdvancementRoot(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementRoot(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onAddAdvancementTask(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementTask(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onAdvancementsCleared() {
+                    if (old != null)
+                        old.onAdvancementsCleared();
+                }
+            });
+
+            Set<Identifier> locations = new HashSet<>();
+            ImmutableMap.Builder<Identifier, AdvancementHolder> builder = ImmutableMap.builder();
+            for (var entry : serverAdvancements.advancements.entrySet()) {
+                Identifier key = entry.getKey();
+                boolean isRecipe = key.getPath().startsWith("recipes/");
+                if (key.getNamespace().equals("minecraft") && ((vanillaAdvancements && !isRecipe) || (vanillaRecipeAdvancements && isRecipe))) {
+                    locations.add(key);
+                } else {
+                    builder.put(key, entry.getValue());
+                }
+            }
+
+            serverAdvancements.advancements = builder.buildOrThrow();
+
+            final Level oldLevel = disableLogger();
+            try {
+                tree.remove(locations);
+            } finally {
+                // Always restore old logger
+                enableLogger(oldLevel);
+            }
+        } finally {
+            // Always uninject advancement listener
+            listener.set(tree, old);
+        }
+
+        final var removePacket = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), removed, Collections.emptyMap(), false);
+
+        // Remove advancements from players
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            var mcPlayer = ((CraftPlayer) player).getHandle();
+            var advs = mcPlayer.getAdvancements();
+            advs.reload(serverAdvancements);
+            firstPacket.setBoolean(advs, false); // Don't clear every client advancement
+            mcPlayer.connection.send(removePacket);
+        }
+    }
+
+    private static Level disableLogger() {
+        if (LOGGER == null) // Fail-safe if LOGGER could not be found by reflections
+            return null;
+
+        Level old = LOGGER.getLevel();
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(Level.OFF);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(Level.OFF);
+        }
+
+        return old;
+    }
+
+    private static void enableLogger(Level toSet) {
+        if (LOGGER == null || toSet == null) // Fail-safe if LOGGER could not be found by reflections
+            return;
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(toSet);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(toSet);
+        }
+    }
+
+    private VanillaAdvancementDisablerWrapper_v26_1_R2() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementDisplayWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementDisplayWrapper_v26_1_R2.java
@@ -1,0 +1,99 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.advancements.AdvancementType;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.world.item.ItemStackTemplate;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class AdvancementDisplayWrapper_v26_1_R2 extends AdvancementDisplayWrapper {
+
+    private final DisplayInfo display;
+    private final AdvancementFrameTypeWrapper frameType;
+
+    public AdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStack icon, @NotNull String title, @NotNull String description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(ItemStackTemplate.fromNonEmptyStack(CraftItemStack.asNMSCopy(icon)), Util.fromString(title), Util.fromString(description), Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    public AdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStack icon, @NotNull BaseComponent title, @NotNull BaseComponent description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(ItemStackTemplate.fromNonEmptyStack(CraftItemStack.asNMSCopy(icon)), Util.fromComponent(title), Util.fromComponent(description), Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    @Override
+    @NotNull
+    public ItemStack getIcon() {
+        return CraftItemStack.asBukkitCopy(display.getIcon().create());
+    }
+
+    @Override
+    @NotNull
+    public String getTitle() {
+        return CraftChatMessage.fromComponent(display.getTitle());
+    }
+
+    @Override
+    @NotNull
+    public String getDescription() {
+        return CraftChatMessage.fromComponent(display.getDescription());
+    }
+
+    @Override
+    @NotNull
+    public AdvancementFrameTypeWrapper getAdvancementFrameType() {
+        return frameType;
+    }
+
+    @Override
+    public float getX() {
+        return display.getX();
+    }
+
+    @Override
+    public float getY() {
+        return display.getY();
+    }
+
+    @Override
+    public boolean doesShowToast() {
+        return display.shouldShowToast();
+    }
+
+    @Override
+    public boolean doesAnnounceToChat() {
+        return display.shouldAnnounceChat();
+    }
+
+    @Override
+    public boolean isHidden() {
+        return display.isHidden();
+    }
+
+    @Override
+    @Nullable
+    public String getBackgroundTexture() {
+        Optional<ClientAsset.ResourceTexture> r = display.getBackground();
+        return r.isEmpty() ? null : r.toString();
+    }
+
+    @Override
+    @NotNull
+    public DisplayInfo toNMS() {
+        return display;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementFrameTypeWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementFrameTypeWrapper_v26_1_R2.java
@@ -1,0 +1,32 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import org.jetbrains.annotations.NotNull;
+
+public class AdvancementFrameTypeWrapper_v26_1_R2 extends AdvancementFrameTypeWrapper {
+
+    private final net.minecraft.advancements.AdvancementType mcFrameType;
+
+    private final FrameType frameType;
+
+    public AdvancementFrameTypeWrapper_v26_1_R2(@NotNull FrameType frameType) {
+        this.frameType = frameType;
+        this.mcFrameType = switch (frameType) {
+            case TASK -> net.minecraft.advancements.AdvancementType.TASK;
+            case GOAL -> net.minecraft.advancements.AdvancementType.GOAL;
+            case CHALLENGE -> net.minecraft.advancements.AdvancementType.CHALLENGE;
+        };
+    }
+
+    @Override
+    @NotNull
+    public FrameType getFrameType() {
+        return frameType;
+    }
+
+    @Override
+    @NotNull
+    public net.minecraft.advancements.AdvancementType toNMS() {
+        return mcFrameType;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementWrapper_v26_1_R2.java
@@ -1,0 +1,88 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AdvancementWrapper_v26_1_R2 extends AdvancementWrapper {
+
+    private final AdvancementHolder advancementHolder;
+    private final MinecraftKeyWrapper key;
+    private final AdvancementWrapper parent;
+    private final AdvancementDisplayWrapper display;
+
+    public AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    public AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @Nullable
+    public AdvancementWrapper getParent() {
+        return parent;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return this.advancementHolder.value().requirements().size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementHolder toNMS() {
+        return advancementHolder;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/PreparedAdvancementWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/PreparedAdvancementWrapper_v26_1_R2.java
@@ -1,0 +1,56 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementWrapper;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+
+public class PreparedAdvancementWrapper_v26_1_R2 extends PreparedAdvancementWrapper {
+
+    private final MinecraftKeyWrapper key;
+    private final AdvancementDisplayWrapper display;
+    private final Map<String, Criterion<?>> advCriteria;
+    private final AdvancementRequirements advRequirements;
+
+    public PreparedAdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        this.key = key;
+        this.display = display;
+        this.advCriteria = Util.getAdvancementCriteria(maxProgression);
+        this.advRequirements = Util.getAdvancementRequirements(advCriteria);
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return advRequirements.size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toRootAdvancementWrapper() {
+        return new AdvancementWrapper_v26_1_R2(key, display, advCriteria, advRequirements);
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toBaseAdvancementWrapper(@NotNull AdvancementWrapper parent) {
+        return new AdvancementWrapper_v26_1_R2(key, parent, display, advCriteria, advRequirements);
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutAdvancementsWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutAdvancementsWrapper_v26_1_R2.java
@@ -1,0 +1,49 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.util.ListSet;
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutAdvancementsWrapper;
+import com.google.common.collect.Maps;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class PacketPlayOutAdvancementsWrapper_v26_1_R2 extends PacketPlayOutAdvancementsWrapper {
+
+    private final ClientboundUpdateAdvancementsPacket packet;
+
+    public PacketPlayOutAdvancementsWrapper_v26_1_R2() {
+        this.packet = new ClientboundUpdateAdvancementsPacket(true, Collections.emptyList(), Collections.emptySet(), Collections.emptyMap(), true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v26_1_R2(@NotNull Map<AdvancementWrapper, Integer> toSend) {
+        Map<Identifier, AdvancementProgress> map = Maps.newHashMapWithExpectedSize(toSend.size());
+        for (Entry<AdvancementWrapper, Integer> e : toSend.entrySet()) {
+            AdvancementWrapper adv = e.getKey();
+            map.put((Identifier) adv.getKey().toNMS(), Util.getAdvancementProgress((AdvancementHolder) adv.toNMS(), e.getValue()));
+        }
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, (Collection<AdvancementHolder>) ListSet.fromWrapperSet(toSend.keySet()), Collections.emptySet(), map, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v26_1_R2(@NotNull Set<MinecraftKeyWrapper> toRemove) {
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), (Set<Identifier>) ListSet.fromWrapperSet(toRemove), Collections.emptyMap(), true);
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2.java
@@ -1,0 +1,27 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutSelectAdvancementTabWrapper;
+import net.minecraft.network.protocol.game.ClientboundSelectAdvancementsTabPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2 extends PacketPlayOutSelectAdvancementTabWrapper {
+
+    private final ClientboundSelectAdvancementsTabPacket packet;
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2() {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) null);
+    }
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key) {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) key.toNMS());
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-common</artifactId>

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ReflectionUtil.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ReflectionUtil.java
@@ -14,10 +14,33 @@ import java.util.Optional;
 public class ReflectionUtil {
 
     /**
-     * The Minecraft version.
-     * <p>For example {@code 1.17.1}.
+     * The complete Minecraft version.
+     * <p>For example {@code 1.17.1} or {@code 26.1.2}.
      */
-    public static final String MINECRAFT_VERSION = Bukkit.getBukkitVersion().split("-")[0];
+    public static final String MINECRAFT_VERSION = getMinecraftVersion();
+
+    private static String getMinecraftVersion() {
+        try {
+            // Paper-only method
+            return (String) Bukkit.class.getDeclaredMethod("getMinecraftVersion").invoke(null);
+        } catch (ReflectiveOperationException e) {
+            return Bukkit.getBukkitVersion().split("-")[0];
+        }
+    }
+
+    /**
+     * The Minecraft major version.
+     * <p>For example, for {@code 1.19.2} it is {@code 1}.
+     * For {@code 26.1.2} it is {@code 26}.
+     */
+    public static final int MAJOR_VERSION;
+
+    /**
+     * The Minecraft version.
+     * <p>For example, for {@code 1.17.1} it is {@code 17}.
+     * For {@code 26.1.2} it is {@code 1}.
+     */
+    public static final int VERSION;
 
     /**
      * The Minecraft minor version.
@@ -27,6 +50,10 @@ public class ReflectionUtil {
 
     static {
         var splitted = MINECRAFT_VERSION.split("\\.");
+
+        MAJOR_VERSION = Integer.parseInt(splitted[0]);
+        VERSION = Integer.parseInt(splitted[1]);
+
         if (splitted.length > 2) {
             MINOR_VERSION = Integer.parseInt(splitted[2]);
         } else {
@@ -35,14 +62,7 @@ public class ReflectionUtil {
     }
 
     private static final String CRAFTBUKKIT_PACKAGE = Bukkit.getServer().getClass().getPackage().getName();
-
-    /**
-     * The NMS version.
-     * <p>For example, for {@code v1_17_R1} it is {@code 17}.
-     */
-    public static final int VERSION = Integer.parseInt(MINECRAFT_VERSION.split("\\.")[1]);
-
-    private static final boolean IS_1_17 = VERSION >= 17;
+    private static final boolean IS_1_17 = MAJOR_VERSION >= 26 || (MAJOR_VERSION == 1 && VERSION >= 17);
 
     /**
      * Returns whether the provided class exists.

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -39,7 +39,8 @@ public class Versions {
             "v1_21_R4",
             "v1_21_R5",
             "v1_21_R6",
-            "v1_21_R7"
+            "v1_21_R7",
+            "v26_1_R2"
     );
 
     private static final Map<String, List<String>> NMS_TO_VERSIONS = Map.ofEntries(
@@ -63,7 +64,8 @@ public class Versions {
             Map.entry("v1_21_R4", List.of("1.21.5")),
             Map.entry("v1_21_R5", List.of("1.21.6", "1.21.7", "1.21.8")),
             Map.entry("v1_21_R6", List.of("1.21.9", "1.21.10")),
-            Map.entry("v1_21_R7", List.of("1.21.11"))
+            Map.entry("v1_21_R7", List.of("1.21.11")),
+            Map.entry("v26_1_R2", List.of("26.1", "26.1.1", "26.1.2"))
     );
 
     private static final Map<String, String> NMS_TO_FANCY = Map.ofEntries(
@@ -87,7 +89,8 @@ public class Versions {
             Map.entry("v1_21_R4", "1.21.5"),
             Map.entry("v1_21_R5", "1.21.6-1.21.8"),
             Map.entry("v1_21_R6", "1.21.9-1.21.10"),
-            Map.entry("v1_21_R7", "1.21.11")
+            Map.entry("v1_21_R7", "1.21.11"),
+            Map.entry("v26_1_R2", "26.1-26.1.2")
     );
 
     private static final List<String> SUPPORTED_VERSIONS = SUPPORTED_NMS_VERSIONS.stream()

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -16,7 +16,7 @@ import java.util.Optional;
  */
 public class Versions {
 
-    private static final String API_VERSION = "2.7.2";
+    private static final String API_VERSION = "2.8.0";
 
     private static final List<String> SUPPORTED_NMS_VERSIONS = List.of(
             "v1_15_R1",

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-distribution</artifactId>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -51,112 +51,112 @@
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R3</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R4</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R3</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R4</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R5</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R6</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -159,7 +159,11 @@
             <classifier>mojang-mapped</classifier>
         </dependency>
 
-        <!-- When adding a version remember to add the CraftBukkit relocation below -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-distribution-mojang-mapped</artifactId>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -61,7 +61,7 @@
                         <execution>
                             <id>generate-mojang-mapped-jar</id>
                             <configuration>
-                                <classifier>mojang-mapped</classifier>
+                                <classifier>mojang-mapped-legacy</classifier>
                             </configuration>
                         </execution>
                     </executions>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -45,6 +45,7 @@
         <module>1_21_R5</module>
         <module>1_21_R6</module>
         <module>1_21_R7</module>
+        <module>26_1_R2</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
     </modules>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-parent</artifactId>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped.jar</mojangMappedJarFile>
+        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped-Legacy.jar</mojangMappedJarFile>
 
         <!-- Skip deploy -->
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -79,7 +79,7 @@
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-shadeable</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
@@ -93,7 +93,7 @@
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-commands</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
@@ -165,8 +165,8 @@
                         <configuration>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>com.frengor:ultimateadvancementapi-shadeable:mojang-mapped</exclude>
-                                    <exclude>com.frengor:ultimateadvancementapi-commands:mojang-mapped</exclude>
+                                    <exclude>com.frengor:ultimateadvancementapi-shadeable:mojang-mapped-legacy</exclude>
+                                    <exclude>com.frengor:ultimateadvancementapi-commands:mojang-mapped-legacy</exclude>
                                 </excludes>
                             </artifactSet>
 
@@ -225,7 +225,7 @@
                                 <artifact>
                                     <file>${mojangMappedJarFile}</file>
                                     <type>jar</type>
-                                    <classifier>mojang-mapped</classifier>
+                                    <classifier>mojang-mapped-legacy</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status main Branch](https://jenkins.frengor.com/job/UltimateAdvancementAPI/job/main/badge/icon?subject=main&style=flat)](https://jenkins.frengor.com/job/UltimateAdvancementAPI/job/main/)
 [![Build Status dev Branch](https://jenkins.frengor.com/job/UltimateAdvancementAPI/job/dev/badge/icon?subject=dev&style=flat)](https://jenkins.frengor.com/job/UltimateAdvancementAPI/job/dev/)
 [![License](https://img.shields.io/badge/license-LGPL--3.0-orange?style=flat)](https://github.com/frengor/UltimateAdvancementAPI/blob/main/LGPL)
-[![Version](https://img.shields.io/badge/version-2.7.2-blue?style=flat&color=007ec6)](https://jenkins.frengor.com/job/UltimateAdvancementAPI/)
+[![Version](https://img.shields.io/badge/version-2.8.0-blue?style=flat&color=007ec6)](https://jenkins.frengor.com/job/UltimateAdvancementAPI/)
 [![Issues](https://img.shields.io/github/issues/frengor/UltimateAdvancementAPI?style=flat)](https://github.com/frengor/UltimateAdvancementAPI/issues)
 [![Stars](https://img.shields.io/github/stars/frengor/UltimateAdvancementAPI?style=flat)](https://github.com/frengor/UltimateAdvancementAPI/stargazers)
 [![Forks](https://img.shields.io/github/forks/frengor/UltimateAdvancementAPI?style=flat)](https://github.com/frengor/UltimateAdvancementAPI/network)
@@ -38,7 +38,7 @@ A powerful API to create custom advancements for your minecraft server.
 <dependency>
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi</artifactId>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi-parent</artifactId>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
     <packaging>pom</packaging>
 
     <name>UltimateAdvancementAPI-Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.11.0</version>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,7 @@
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.release>16</maven.compiler.release>
     </properties>
 
     <repositories>


### PR DESCRIPTION
* Updated version to 2.8.0
* Updated to Minecraft 26.1.2
* Updated CommandAPI to 11.2.0
* Renamed the `mojang-mapped` classifier to `mojang-mapped-legacy`. Starting from 26.1.2, both Spigot and Paper are mojang mapped, so the mojang-mapped versions are only useful on (mojang mapped) Paper 1.18-1.21.11 servers.
* Minor improvements