### PR TITLE
Update to 3.0.0-beta-2

### DIFF
--- a/Commands/CommandAPI-10.1.2/pom.xml
+++ b/Commands/CommandAPI-10.1.2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-10.1.2</artifactId>

--- a/Commands/CommandAPI-11.2.0/pom.xml
+++ b/Commands/CommandAPI-11.2.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>

--- a/Commands/CommandAPI-11.2.0/pom.xml
+++ b/Commands/CommandAPI-11.2.0/pom.xml
@@ -10,8 +10,8 @@
         <version>3.0.0-beta-1</version>
     </parent>
 
-    <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
-    <name>UltimateAdvancementAPI-Commands-CommandAPI-11.1.0</name>
+    <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>
+    <name>UltimateAdvancementAPI-Commands-CommandAPI-11.2.0</name>
     <url>${parent.url}</url>
     <packaging>jar</packaging>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-spigot-core</artifactId>
-            <version>11.1.0</version>
+            <version>11.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementArgument.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementTabArgument.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/AdvancementTabArgument.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/CommandAPIManager.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/CommandAPIManager.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;

--- a/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/UltimateAdvancementAPICommand.java
+++ b/Commands/CommandAPI-11.2.0/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/commandAPI_v11_2_0/UltimateAdvancementAPICommand.java
@@ -1,4 +1,4 @@
-package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0;
+package com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0;
 
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.Objects;
 
 import static com.fren_gor.ultimateAdvancementAPI.commands.CommandAPIManager.*;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0.AdvancementArgument.getAdvancementArgument;
-import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_1_0.AdvancementTabArgument.getAdvancementTabArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0.AdvancementArgument.getAdvancementArgument;
+import static com.fren_gor.ultimateAdvancementAPI.commands.commandAPI_v11_2_0.AdvancementTabArgument.getAdvancementTabArgument;
 
 public class UltimateAdvancementAPICommand {
 

--- a/Commands/CommandAPI-9.3.0/pom.xml
+++ b/Commands/CommandAPI-9.3.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9.3.0</artifactId>

--- a/Commands/CommandAPI-9.7.0/pom.xml
+++ b/Commands/CommandAPI-9.7.0/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-commandapi-9.7.0</artifactId>

--- a/Commands/Common/pom.xml
+++ b/Commands/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-common</artifactId>

--- a/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
+++ b/Commands/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/CommandAPIVersion.java
@@ -59,16 +59,17 @@ public enum CommandAPIVersion {
                     "v1_21_R4"
             )
     ),
-    LATEST("11.1.0",
+    LATEST("11.2.0",
             "commandapi-spigot-shade",
             "commandapi-paper-shade",
-            "E0rUSMwJKIHP5skpdscHMhq4VslVNnfcxh4QnY8N2Vw=",
-            "WG0DkQHBm8me54fVf5e3lVY+50qwvvOFhApxT+na+Ho=",
-            "11_1_0",
+            "Kx6c7DPWPyFkrmlEYq1hj6VeQm4BbBBMbthKI1pHLes=",
+            "F6KljlYn01+rt6JIKJPOKmWI++d46LgeOd8e6dw6gIM=",
+            "11_2_0",
             List.of(
                     "v1_21_R5",
                     "v1_21_R6",
-                    "v1_21_R7"
+                    "v1_21_R7",
+                    "v26_1_R2"
             )
     );
 

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/Distribution/pom.xml
+++ b/Commands/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-distribution</artifactId>

--- a/Commands/Distribution/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/MojangMappingsHandler.java
+++ b/Commands/Distribution/src/main/java/com/fren_gor/ultimateAdvancementAPI/commands/MojangMappingsHandler.java
@@ -16,7 +16,7 @@ public final class MojangMappingsHandler {
      */
     public static boolean isMojangMapped() {
         // Load the Mojang mapped CommandAPI on Paper 1.20.6+ as a workaround for https://github.com/PaperMC/Paper/issues/10713
-        return IS_PAPER && (ReflectionUtil.VERSION > 20 || (ReflectionUtil.VERSION == 20 && ReflectionUtil.MINOR_VERSION >= 6));
+        return IS_PAPER && (ReflectionUtil.MAJOR_VERSION >= 26 || (ReflectionUtil.MAJOR_VERSION == 1 && (ReflectionUtil.VERSION > 20 || (ReflectionUtil.VERSION == 20 && ReflectionUtil.MINOR_VERSION >= 6))));
     }
 
     private MojangMappingsHandler() {

--- a/Commands/DistributionMojangMapped/pom.xml
+++ b/Commands/DistributionMojangMapped/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.frengor</groupId>
-            <artifactId>ultimateadvancementapi-commands-commandapi-11.1.0</artifactId>
+            <artifactId>ultimateadvancementapi-commands-commandapi-11.2.0</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Commands/DistributionMojangMapped/pom.xml
+++ b/Commands/DistributionMojangMapped/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-commands-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-distribution-mojang-mapped</artifactId>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>ultimateadvancementapi-parent</artifactId>
         <groupId>com.frengor</groupId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands-parent</artifactId>

--- a/Commands/pom.xml
+++ b/Commands/pom.xml
@@ -25,7 +25,7 @@
         <module>CommandAPI-9.3.0</module>
         <module>CommandAPI-9.7.0</module>
         <module>CommandAPI-10.1.2</module>
-        <module>CommandAPI-11.1.0</module>
+        <module>CommandAPI-11.2.0</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
     </modules>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-common</artifactId>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -35,9 +35,17 @@
         <!-- Put before every other dependency (except bungeecord-chat) in order to have it loaded before Spigot -->
         <!-- See https://github.com/MockBukkit/MockBukkit/issues/462 and https://github.com/MockBukkit/MockBukkit/issues/462#issuecomment-1156574495 -->
         <dependency>
-            <groupId>com.github.seeseemelk</groupId>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
             <artifactId>${mockBukkitArtifact}</artifactId>
             <version>${mockBukkitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Paper API for tests (MockBukkit is based on Paper, so we can use it in tests) -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${mockBukkitPaperAPIVersion}</version>
             <scope>test</scope>
         </dependency>
 

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
@@ -92,7 +92,8 @@ public final class DatabaseManager implements Closeable {
     // since the latter can't be used inside lambdas, which are very commonly used in the code
 
     private static final int LOAD_EVENTS_DELAY = 3;
-    private static final boolean IS_PAPER = ReflectionUtil.classExists("io.papermc.paper.advancement.AdvancementDisplay");
+    private static final boolean IS_PAPER = ReflectionUtil.classExists("io.papermc.paper.advancement.AdvancementDisplay")
+            && !ReflectionUtil.classExists("org.mockbukkit.mockbukkit.MockBukkit"); // Workaround: MockBukkit doesn't call PlayerConnectionInitialConfigureEvent
 
     // A single-thread executor is used to maintain executed queries sequential
     private final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("DatabaseManager Thread - %d").build());

--- a/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
+++ b/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManager.java
@@ -149,7 +149,7 @@ public final class DatabaseManager implements Closeable {
         database.setUp();
 
         // Don't use PlayerLoginEvent on Paper 1.21.7+
-        if (IS_PAPER && (ReflectionUtil.VERSION > 21 || (ReflectionUtil.VERSION == 21 && ReflectionUtil.MINOR_VERSION >= 7))) {
+        if (IS_PAPER && (ReflectionUtil.MAJOR_VERSION >= 26 || (ReflectionUtil.MAJOR_VERSION == 1 && (ReflectionUtil.VERSION > 21 || (ReflectionUtil.VERSION == 21 && ReflectionUtil.MINOR_VERSION >= 7))))) {
             DBPaperEvents events = new DBPaperEvents(logger, eventManager);
             events.registerPlayerConnectionInitialConfigureEvent(this, this::loadPlayerOnConnect);
             events.registerPlayerConnectionCloseEvent(this, this::unloadPlayerOnDisconnect);

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/AdvancementMainTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/AdvancementMainTest.java
@@ -1,7 +1,5 @@
 package com.fren_gor.ultimateAdvancementAPI;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.MockPlugin;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.InvalidVersionException;
 import com.fren_gor.ultimateAdvancementAPI.tests.MockedServerClass;
 import com.fren_gor.ultimateAdvancementAPI.tests.NoAdvancementMain;
@@ -9,6 +7,8 @@ import com.fren_gor.ultimateAdvancementAPI.tests.UAAPIExtension;
 import org.bukkit.craftbukkit.notMocked99_0_R3.NotMockedServerMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,7 +19,7 @@ public class AdvancementMainTest {
     @MockedServerClass(serverClass = NotMockedServerMock.class)
     @NoAdvancementMain
     void loadingWithUnsupportedVersion() {
-        MockPlugin pl = MockBukkit.createMockPlugin();
+        PluginMock pl = MockBukkit.createMockPlugin();
         AdvancementMain main = new AdvancementMain(pl);
         assertThrows(InvalidVersionException.class, main::load);
         assertThrows(InvalidVersionException.class, () -> main.enable(() -> null));

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/AdvancementTabTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/AdvancementTabTest.java
@@ -1,10 +1,10 @@
 package com.fren_gor.ultimateAdvancementAPI;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
 import com.fren_gor.ultimateAdvancementAPI.tests.AutoInject;
 import com.fren_gor.ultimateAdvancementAPI.tests.UAAPIExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 @ExtendWith(UAAPIExtension.class)
 public class AdvancementTabTest {

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/MultiTasksAdvancementTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/advancement/tasks/MultiTasksAdvancementTest.java
@@ -1,6 +1,5 @@
 package com.fren_gor.ultimateAdvancementAPI.advancement.tasks;
 
-import be.seeseemelk.mockbukkit.ServerMock;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.RootAdvancement;
@@ -17,6 +16,7 @@ import org.bukkit.entity.Player;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 import static com.fren_gor.ultimateAdvancementAPI.tests.Utils.waitCompletion;
 

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManagerTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/database/DatabaseManagerTest.java
@@ -1,9 +1,5 @@
 package com.fren_gor.ultimateAdvancementAPI.database;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.MockPlugin;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import com.fren_gor.eventManagerAPI.EventManager;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.TeamNotRegisteredException;
@@ -28,6 +24,10 @@ import com.fren_gor.ultimateAdvancementAPI.util.AdvancementUtils;
 import org.bukkit.Bukkit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -341,7 +341,7 @@ public class DatabaseManagerTest {
         PlayerMock p = loadPlayer();
         TeamProgression trueTeam = dbManager.getTeamProgression(p);
         disconnectPlayer(p);
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         TeamProgression team = waitCompletion(dbManager.loadAndAddLoadingRequest(p.getUniqueId(), plugin)).get();
         assertEquals(1, dbManager.getLoadingRequestsAmount(p.getUniqueId(), plugin));
         assertEquals(trueTeam.getTeamId(), team.getTeamId());
@@ -357,7 +357,7 @@ public class DatabaseManagerTest {
     void loadAndAddLoadingRequestToPlayerWithFailureTest() throws Exception {
         PlayerMock p = loadPlayer();
         disconnectPlayer(p);
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         dbImpls.getFallible().setFallibleOps(DBOperation.LOAD_UUID);
         dbImpls.getFallible().addToPlanning(false);
         assertTrue(waitCompletion(dbManager.loadAndAddLoadingRequest(p.getUniqueId(), plugin)).isCompletedExceptionally());
@@ -368,7 +368,7 @@ public class DatabaseManagerTest {
 
     @Test
     void loadAndAddLoadingRequestToPlayerWithNonRegisteredPlayerTest() throws Exception {
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         UUID uuid = UUID.randomUUID();
         plugin.getLogger().warning("Expecting a " + UserNotRegisteredException.class.getSimpleName() + " for user " + uuid + '.');
         var cf = waitCompletion(dbManager.loadAndAddLoadingRequest(uuid, plugin));
@@ -413,7 +413,7 @@ public class DatabaseManagerTest {
         final Object listener = new Object();
         final EventManager manager = advancementMain.getEventManager();
 
-        final MockPlugin plugin = MockBukkit.createMockPlugin();
+        final PluginMock plugin = MockBukkit.createMockPlugin();
         final PlayerMock p = server.addPlayer();
 
         try {
@@ -628,7 +628,7 @@ public class DatabaseManagerTest {
 
     @Test
     void createNewTeamTest() throws Exception {
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         PlayerMock p1 = loadPlayer();
 
         TeamProgression team = waitCompletion(dbManager.createNewTeamWithOneLoadingRequest(plugin)).get();
@@ -649,7 +649,7 @@ public class DatabaseManagerTest {
 
     @Test
     void createNewTeamAndMovePlayerInsideTest() throws Exception {
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         PlayerMock p1 = loadPlayer();
 
         TeamProgression t1 = dbManager.getTeamProgression(p1);
@@ -672,7 +672,7 @@ public class DatabaseManagerTest {
 
     @Test
     void makeSurePlayerAreNotMovedBeforeRegisterEventTest() throws Exception {
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         TeamProgression team = waitCompletion(dbManager.createNewTeamWithOneLoadingRequest(plugin)).get();
 
         Paused paused = dbManagerUtils.pauseFutureTasks();
@@ -703,7 +703,7 @@ public class DatabaseManagerTest {
 
     @Test
     void loadTeamTest() throws Exception {
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
 
         plugin.getLogger().warning("Expecting a " + TeamNotRegisteredException.class.getSimpleName() + " for team -1.");
         var invalidTeamCf = waitCompletion(dbManager.loadAndAddLoadingRequest(-1, plugin));
@@ -734,7 +734,7 @@ public class DatabaseManagerTest {
 
     @Test
     void loadTeamWithFailureTest() throws Exception {
-        MockPlugin plugin = MockBukkit.createMockPlugin();
+        PluginMock plugin = MockBukkit.createMockPlugin();
         dbImpls.getFallible().setFallibleOps(DBOperation.LOAD_TEAM);
         dbImpls.getFallible().addToPlanning(false);
 

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/database/JoinEventWaiterTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/database/JoinEventWaiterTest.java
@@ -1,13 +1,13 @@
 package com.fren_gor.ultimateAdvancementAPI.database;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
 import com.fren_gor.ultimateAdvancementAPI.tests.AutoInject;
 import com.fren_gor.ultimateAdvancementAPI.tests.UAAPIExtension;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/UAAPIExtension.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/UAAPIExtension.java
@@ -1,8 +1,5 @@
 package com.fren_gor.ultimateAdvancementAPI.tests;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.database.DatabaseManager;
 import com.fren_gor.ultimateAdvancementAPI.tests.Utils.AbstractMockedServer;
@@ -20,6 +17,9 @@ import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/Utils.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/tests/Utils.java
@@ -1,7 +1,5 @@
 package com.fren_gor.ultimateAdvancementAPI.tests;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.database.IDatabase;
 import com.fren_gor.ultimateAdvancementAPI.exceptions.DatabaseException;
@@ -12,6 +10,8 @@ import org.bukkit.craftbukkit.mocked0_0_R1.VersionedServerMock;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;

--- a/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/util/CoordAdapterTest.java
+++ b/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/util/CoordAdapterTest.java
@@ -1,6 +1,5 @@
 package com.fren_gor.ultimateAdvancementAPI.util;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementMain;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
 import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
@@ -16,6 +15,7 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 import java.util.Collection;
 import java.util.List;

--- a/Common/src/test/java/org/bukkit/craftbukkit/mocked0_0_R1/VersionedServerMock.java
+++ b/Common/src/test/java/org/bukkit/craftbukkit/mocked0_0_R1/VersionedServerMock.java
@@ -1,10 +1,10 @@
 package org.bukkit.craftbukkit.mocked0_0_R1;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
 import com.fren_gor.ultimateAdvancementAPI.nms.util.ReflectionUtil;
 import com.fren_gor.ultimateAdvancementAPI.tests.Utils.AbstractMockedServer;
 import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 import java.util.Optional;
 

--- a/CommonPaper/pom.xml
+++ b/CommonPaper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-common-paper</artifactId>

--- a/CommonPaper/src/main/java/com/fren_gor/ultimateAdvancementAPI/PaperEvents.java
+++ b/CommonPaper/src/main/java/com/fren_gor/ultimateAdvancementAPI/PaperEvents.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 final class PaperEvents {
 
     // ServerResourcesReloadedEvent was added in Paper 1.16.4
-    public static final boolean IS_SERVER_RESOURCES_RELOADED_EVENT_SUPPORTED = ReflectionUtil.VERSION > 16 || (ReflectionUtil.VERSION == 16 && ReflectionUtil.MINOR_VERSION >= 4);
+    public static final boolean IS_SERVER_RESOURCES_RELOADED_EVENT_SUPPORTED = ReflectionUtil.MAJOR_VERSION >= 26 || (ReflectionUtil.MAJOR_VERSION == 1 && (ReflectionUtil.VERSION > 16 || (ReflectionUtil.VERSION == 16 && ReflectionUtil.MINOR_VERSION >= 4)));
 
     private final EventManager eventManager;
 

--- a/Distribution/API/pom.xml
+++ b/Distribution/API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi</artifactId>

--- a/Distribution/Commands/pom.xml
+++ b/Distribution/Commands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-commands</artifactId>

--- a/Distribution/Shadeable/pom.xml
+++ b/Distribution/Shadeable/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-distribution</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-shadeable</artifactId>

--- a/Distribution/pom.xml
+++ b/Distribution/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <!-- (optionally) overridden by modules -->
         <javadocArtifactId>ultimateadvancementapi-common</javadocArtifactId>
-        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped.jar</mojangMappedJarFile>
+        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped-Legacy.jar</mojangMappedJarFile>
         <artifactIdToExclude>overridden-by-modules</artifactIdToExclude>
     </properties>
 
@@ -155,7 +155,7 @@
                                     <artifact>
                                         <file>${mojangMappedJarFile}</file>
                                         <type>jar</type>
-                                        <classifier>mojang-mapped</classifier>
+                                        <classifier>mojang-mapped-legacy</classifier>
                                     </artifact>
                                 </artifacts>
                             </configuration>

--- a/Distribution/pom.xml
+++ b/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-distribution</artifactId>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     }
     tools {
         maven 'Maven'
-        jdk 'jdk21'
+        jdk 'jdk25'
     }
 
     stages {

--- a/NMS/1_15_R1/pom.xml
+++ b/NMS/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_15_R1</artifactId>

--- a/NMS/1_16_R1/pom.xml
+++ b/NMS/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R1</artifactId>

--- a/NMS/1_16_R2/pom.xml
+++ b/NMS/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R2</artifactId>

--- a/NMS/1_16_R3/pom.xml
+++ b/NMS/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_16_R3</artifactId>

--- a/NMS/1_17_R1/pom.xml
+++ b/NMS/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_17_R1</artifactId>

--- a/NMS/1_18_R1/pom.xml
+++ b/NMS/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>

--- a/NMS/1_18_R2/pom.xml
+++ b/NMS/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>

--- a/NMS/1_19_R1/pom.xml
+++ b/NMS/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>

--- a/NMS/1_19_R2/pom.xml
+++ b/NMS/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>

--- a/NMS/1_19_R3/pom.xml
+++ b/NMS/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>

--- a/NMS/1_20_R1/pom.xml
+++ b/NMS/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>

--- a/NMS/1_20_R2/pom.xml
+++ b/NMS/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R2</artifactId>

--- a/NMS/1_20_R3/pom.xml
+++ b/NMS/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R3</artifactId>

--- a/NMS/1_20_R4/pom.xml
+++ b/NMS/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_20_R4</artifactId>

--- a/NMS/1_21_R1/pom.xml
+++ b/NMS/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R1</artifactId>

--- a/NMS/1_21_R2/pom.xml
+++ b/NMS/1_21_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R2</artifactId>

--- a/NMS/1_21_R3/pom.xml
+++ b/NMS/1_21_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R3</artifactId>

--- a/NMS/1_21_R4/pom.xml
+++ b/NMS/1_21_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R4</artifactId>

--- a/NMS/1_21_R5/pom.xml
+++ b/NMS/1_21_R5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R5</artifactId>

--- a/NMS/1_21_R6/pom.xml
+++ b/NMS/1_21_R6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R6</artifactId>

--- a/NMS/1_21_R7/pom.xml
+++ b/NMS/1_21_R7/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>

--- a/NMS/26_1_R2/pom.xml
+++ b/NMS/26_1_R2/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.frengor</groupId>
+        <artifactId>ultimateadvancementapi-nms-parent</artifactId>
+        <version>3.0.0-beta-1</version>
+    </parent>
+
+    <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>
+    <name>UltimateAdvancementAPI-NMS-26_1_R2</name>
+    <url>${parent.url}</url>
+    <packaging>jar</packaging>
+
+    <properties>
+        <mc-version>26.1.2-R0.1-SNAPSHOT</mc-version>
+    </properties>
+
+    <dependencies>
+        <!-- Spigot API -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spigot -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>${mc-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- NMS Common Module -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>../..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>LGPL</include>
+                    <include>NOTICE</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/NMS/26_1_R2/pom.xml
+++ b/NMS/26_1_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/MinecraftKeyWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/MinecraftKeyWrapper_v26_1_R2.java
@@ -1,0 +1,46 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import net.minecraft.IdentifierException;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class MinecraftKeyWrapper_v26_1_R2 extends MinecraftKeyWrapper {
+
+    private final Identifier key;
+
+    public MinecraftKeyWrapper_v26_1_R2(@NotNull Object key) {
+        this.key = (Identifier) key;
+    }
+
+    public MinecraftKeyWrapper_v26_1_R2(@NotNull String namespace, @NotNull String key) {
+        try {
+            this.key = Identifier.fromNamespaceAndPath(namespace, key);
+        } catch (IdentifierException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    @Override
+    @NotNull
+    public String getNamespace() {
+        return key.getNamespace();
+    }
+
+    @Override
+    @NotNull
+    public String getKey() {
+        return key.getPath();
+    }
+
+    @Override
+    public int compareTo(@NotNull MinecraftKeyWrapper obj) {
+        return key.compareTo((Identifier) obj.toNMS());
+    }
+
+    @Override
+    @NotNull
+    public Identifier toNMS() {
+        return key;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/Util.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/Util.java
@@ -1,0 +1,138 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.gson.JsonParseException;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.CriterionProgress;
+import net.minecraft.advancements.criterion.ImpossibleTrigger;
+import net.minecraft.advancements.criterion.ImpossibleTrigger.TriggerInstance;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.resources.Identifier;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class Util {
+
+    public static final Logger ERROR = Logger.getLogger("UltimateAdvancementAPI-NMS");
+
+    @NotNull
+    public static Map<String, Criterion<?>> getAdvancementCriteria(@Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Preconditions.checkArgument(maxProgression >= 1, "Max progression must be >= 1.");
+
+        Map<String, Criterion<?>> advCriteria = Maps.newHashMapWithExpectedSize(maxProgression);
+        for (int i = 0; i < maxProgression; i++) {
+            advCriteria.put(String.valueOf(i), new Criterion<>(new ImpossibleTrigger(), new TriggerInstance()));
+        }
+
+        return advCriteria;
+    }
+
+    @NotNull
+    public static AdvancementRequirements getAdvancementRequirements(@NotNull Map<String, Criterion<?>> advCriteria) {
+        Preconditions.checkNotNull(advCriteria, "Advancement criteria map is null.");
+
+        List<List<String>> list = new ArrayList<>(advCriteria.size());
+        for (String name : advCriteria.keySet()) {
+            list.add(List.of(name));
+        }
+
+        return new AdvancementRequirements(list);
+    }
+
+    @NotNull
+    public static AdvancementProgress getAdvancementProgress(@NotNull AdvancementHolder mcAdv, @Range(from = 0, to = Integer.MAX_VALUE) int progression) {
+        Preconditions.checkNotNull(mcAdv, "NMS Advancement is null.");
+        Preconditions.checkArgument(progression >= 0, "Progression must be >= 0.");
+
+        AdvancementProgress advPrg = new AdvancementProgress();
+        advPrg.update(mcAdv.value().requirements());
+
+        for (int i = 0; i < progression; i++) {
+            CriterionProgress criteriaPrg = advPrg.getCriterion(String.valueOf(i));
+            if (criteriaPrg != null) {
+                criteriaPrg.grant();
+            }
+        }
+
+        return advPrg;
+    }
+
+    @NotNull
+    public static Component fromString(@NotNull String string) {
+        if (string == null || string.isEmpty()) {
+            return CommonComponents.EMPTY;
+        }
+        return CraftChatMessage.fromStringOrNull(string, true);
+    }
+
+    @NotNull
+    public static Component fromComponent(@NotNull BaseComponent component) {
+        if (component == null) {
+            return CommonComponents.EMPTY;
+        }
+        return fromJSON(ComponentSerializer.toString(component)); // Should never throw JsonParseException
+    }
+
+    @NotNull
+    public static Component fromJSON(@NotNull String json) throws JsonParseException {
+        if (json == null) {
+            return CommonComponents.EMPTY;
+        }
+        return CraftChatMessage.fromJSON(json);
+    }
+
+    @NotNull
+    public static BaseComponent toComponent(@NotNull Component component) {
+        if (component == null) {
+            return new TextComponent("");
+        }
+        return ComponentSerializer.deserialize(CraftChatMessage.toJSON(component));
+    }
+
+    @Nullable
+    public static ClientAsset.ResourceTexture parseBackgroundTexture(@Nullable String backgroundTexture) {
+        if (backgroundTexture == null) {
+            return null;
+        }
+
+        Identifier texturePath = Identifier.parse(backgroundTexture);
+        if (!texturePath.getPath().startsWith("textures/") || !texturePath.getPath().endsWith(".png")) {
+            ERROR.severe("Invalid background texture \"" + backgroundTexture + "\" (the path should be in the form \"textures/**.png\")");
+            return null;
+        }
+
+        Identifier id = texturePath.withPath(path -> {
+            return path.substring("textures/".length(), path.length() - ".png".length());
+        });
+        return new ClientAsset.ResourceTexture(id, texturePath);
+    }
+
+    public static void sendTo(@NotNull Player player, @NotNull Packet<?> packet) {
+        Preconditions.checkNotNull(player, "Player is null.");
+        Preconditions.checkNotNull(packet, "Packet is null.");
+        ((CraftPlayer) player).getHandle().connection.send(packet);
+    }
+
+    private Util() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/VanillaAdvancementDisablerWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/VanillaAdvancementDisablerWrapper_v26_1_R2.java
@@ -1,0 +1,184 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.VanillaAdvancementDisablerWrapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementNode;
+import net.minecraft.advancements.AdvancementTree;
+import net.minecraft.advancements.AdvancementTree.Listener;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.ServerAdvancementManager;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.simple.SimpleLogger;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class VanillaAdvancementDisablerWrapper_v26_1_R2 extends VanillaAdvancementDisablerWrapper {
+
+    private static Logger LOGGER = null;
+    private static Field listener, firstPacket;
+
+    static {
+        try {
+            listener = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == AdvancementTree.Listener.class).findFirst().orElseThrow();
+            listener.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            firstPacket = Arrays.stream(PlayerAdvancements.class.getDeclaredFields()).filter(f -> f.getType() == boolean.class).findFirst().orElseThrow();
+            firstPacket.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Field logger = Arrays.stream(AdvancementTree.class.getDeclaredFields()).filter(f -> f.getType() == org.slf4j.Logger.class).findFirst().orElseThrow();
+            logger.setAccessible(true);
+            org.slf4j.Logger slf4jLogger = (org.slf4j.Logger) logger.get(null);
+            LOGGER = Arrays.stream(slf4jLogger.getClass().getDeclaredFields()).filter(f -> !Modifier.isStatic(f.getModifiers())).map(f -> {
+                try {
+                    f.setAccessible(true);
+                    if (f.get(slf4jLogger) instanceof Logger log) {
+                        return log;
+                    }
+                } catch (ReflectiveOperationException e) {
+                    e.printStackTrace();
+                }
+                return null;
+            }).filter(Objects::nonNull).findFirst().orElseThrow();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void disableVanillaAdvancements(boolean vanillaAdvancements, boolean vanillaRecipeAdvancements) throws Exception {
+        ServerAdvancementManager serverAdvancements = ((CraftServer) Bukkit.getServer()).getServer().getAdvancements();
+        AdvancementTree tree = serverAdvancements.tree();
+
+        if (serverAdvancements.advancements.isEmpty()) {
+            return;
+        }
+
+        final Set<Identifier> removed = Sets.newHashSetWithExpectedSize(serverAdvancements.advancements.size());
+
+        // Inject AdvancementTree listener
+        final Listener old = (Listener) listener.get(tree);
+        try {
+            listener.set(tree, new Listener() {
+                @Override
+                public void onAddAdvancementRoot(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementRoot(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementRoot(advancement);
+                }
+
+                @Override
+                public void onAddAdvancementTask(AdvancementNode advancement) {
+                    if (old != null)
+                        old.onAddAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onRemoveAdvancementTask(AdvancementNode advancement) {
+                    removed.add(advancement.holder().id());
+                    if (old != null)
+                        old.onRemoveAdvancementTask(advancement);
+                }
+
+                @Override
+                public void onAdvancementsCleared() {
+                    if (old != null)
+                        old.onAdvancementsCleared();
+                }
+            });
+
+            Set<Identifier> locations = new HashSet<>();
+            ImmutableMap.Builder<Identifier, AdvancementHolder> builder = ImmutableMap.builder();
+            for (var entry : serverAdvancements.advancements.entrySet()) {
+                Identifier key = entry.getKey();
+                boolean isRecipe = key.getPath().startsWith("recipes/");
+                if (key.getNamespace().equals("minecraft") && ((vanillaAdvancements && !isRecipe) || (vanillaRecipeAdvancements && isRecipe))) {
+                    locations.add(key);
+                } else {
+                    builder.put(key, entry.getValue());
+                }
+            }
+
+            serverAdvancements.advancements = builder.buildOrThrow();
+
+            final Level oldLevel = disableLogger();
+            try {
+                tree.remove(locations);
+            } finally {
+                // Always restore old logger
+                enableLogger(oldLevel);
+            }
+        } finally {
+            // Always uninject advancement listener
+            listener.set(tree, old);
+        }
+
+        final var removePacket = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), removed, Collections.emptyMap(), false);
+
+        // Remove advancements from players
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            var mcPlayer = ((CraftPlayer) player).getHandle();
+            var advs = mcPlayer.getAdvancements();
+            advs.reload(serverAdvancements);
+            firstPacket.setBoolean(advs, false); // Don't clear every client advancement
+            mcPlayer.connection.send(removePacket);
+        }
+    }
+
+    private static Level disableLogger() {
+        if (LOGGER == null) // Fail-safe if LOGGER could not be found by reflections
+            return null;
+
+        Level old = LOGGER.getLevel();
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(Level.OFF);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(Level.OFF);
+        }
+
+        return old;
+    }
+
+    private static void enableLogger(Level toSet) {
+        if (LOGGER == null || toSet == null) // Fail-safe if LOGGER could not be found by reflections
+            return;
+
+        // Method setLevel is not present in Logger interface
+        if (LOGGER instanceof org.apache.logging.log4j.core.Logger coreLogger) {
+            coreLogger.setLevel(toSet);
+        } else if (LOGGER instanceof SimpleLogger simple) {
+            simple.setLevel(toSet);
+        }
+    }
+
+    private VanillaAdvancementDisablerWrapper_v26_1_R2() {
+        throw new UnsupportedOperationException("Utility class.");
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementDisplayWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementDisplayWrapper_v26_1_R2.java
@@ -1,0 +1,102 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.util.JsonString;
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import com.google.gson.JsonParseException;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.advancements.AdvancementType;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStackTemplate;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class AdvancementDisplayWrapper_v26_1_R2 extends AdvancementDisplayWrapper {
+
+    private final DisplayInfo display;
+    private final AdvancementFrameTypeWrapper frameType;
+
+    public AdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStack icon, @NotNull BaseComponent title, @NotNull BaseComponent description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        this(ItemStackTemplate.fromNonEmptyStack(CraftItemStack.asNMSCopy(icon)), Util.fromComponent(title), Util.fromComponent(description), frameType, x, y, showToast, announceChat, hidden, backgroundTexture);
+    }
+
+    public AdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStack icon, @NotNull JsonString jsonTitle, @NotNull JsonString jsonDescription, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) throws JsonParseException {
+        this(ItemStackTemplate.fromNonEmptyStack(CraftItemStack.asNMSCopy(icon)), Util.fromJSON(jsonTitle.jsonString()), Util.fromJSON(jsonDescription.jsonString()), frameType, x, y, showToast, announceChat, hidden, backgroundTexture);
+    }
+
+    protected AdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStackTemplate icon, @NotNull Component title, @NotNull Component description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden, @Nullable String backgroundTexture) {
+        ClientAsset.ResourceTexture clientAsset = Util.parseBackgroundTexture(backgroundTexture);
+        this.display = new DisplayInfo(icon, title, description, Optional.ofNullable(clientAsset), (AdvancementType) frameType.toNMS(), showToast, announceChat, hidden);
+        this.display.setLocation(x, y);
+        this.frameType = frameType;
+    }
+
+    @Override
+    @NotNull
+    public ItemStack getIcon() {
+        return CraftItemStack.asBukkitCopy(display.getIcon().create());
+    }
+
+    @Override
+    @NotNull
+    public BaseComponent getTitle() {
+        return Util.toComponent(display.getTitle());
+    }
+
+    @Override
+    @NotNull
+    public BaseComponent getDescription() {
+        return Util.toComponent(display.getDescription());
+    }
+
+    @Override
+    @NotNull
+    public AdvancementFrameTypeWrapper getAdvancementFrameType() {
+        return frameType;
+    }
+
+    @Override
+    public float getX() {
+        return display.getX();
+    }
+
+    @Override
+    public float getY() {
+        return display.getY();
+    }
+
+    @Override
+    public boolean doesShowToast() {
+        return display.shouldShowToast();
+    }
+
+    @Override
+    public boolean doesAnnounceToChat() {
+        return display.shouldAnnounceChat();
+    }
+
+    @Override
+    public boolean isHidden() {
+        return display.isHidden();
+    }
+
+    @Override
+    @Nullable
+    public String getBackgroundTexture() {
+        Optional<ClientAsset.ResourceTexture> r = display.getBackground();
+        return r.isEmpty() ? null : r.toString();
+    }
+
+    @Override
+    @NotNull
+    public DisplayInfo toNMS() {
+        return display;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementFrameTypeWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementFrameTypeWrapper_v26_1_R2.java
@@ -1,0 +1,32 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import org.jetbrains.annotations.NotNull;
+
+public class AdvancementFrameTypeWrapper_v26_1_R2 extends AdvancementFrameTypeWrapper {
+
+    private final net.minecraft.advancements.AdvancementType mcFrameType;
+
+    private final FrameType frameType;
+
+    public AdvancementFrameTypeWrapper_v26_1_R2(@NotNull FrameType frameType) {
+        this.frameType = frameType;
+        this.mcFrameType = switch (frameType) {
+            case TASK -> net.minecraft.advancements.AdvancementType.TASK;
+            case GOAL -> net.minecraft.advancements.AdvancementType.GOAL;
+            case CHALLENGE -> net.minecraft.advancements.AdvancementType.CHALLENGE;
+        };
+    }
+
+    @Override
+    @NotNull
+    public FrameType getFrameType() {
+        return frameType;
+    }
+
+    @Override
+    @NotNull
+    public net.minecraft.advancements.AdvancementType toNMS() {
+        return mcFrameType;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/AdvancementWrapper_v26_1_R2.java
@@ -1,0 +1,89 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementWrapper;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.DisplayInfo;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AdvancementWrapper_v26_1_R2 extends AdvancementWrapper {
+
+    private final AdvancementHolder advancementHolder;
+    private final MinecraftKeyWrapper key;
+    private final PreparedAdvancementWrapper parent;
+    private final AdvancementDisplayWrapper display;
+
+    public AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    public AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull PreparedAdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        Map<String, Criterion<?>> advCriteria = Util.getAdvancementCriteria(maxProgression);
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, Util.getAdvancementRequirements(advCriteria), false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.empty(), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = null;
+        this.display = display;
+    }
+
+    protected AdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @NotNull PreparedAdvancementWrapper parent, @NotNull AdvancementDisplayWrapper display, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        Advancement advancement = new Advancement(Optional.of((Identifier) parent.getKey().toNMS()), Optional.of((DisplayInfo) display.toNMS()), AdvancementRewards.EMPTY, advCriteria, advRequirements, false, Optional.empty());
+        this.advancementHolder = new AdvancementHolder((Identifier) key.toNMS(), advancement);
+        this.key = key;
+        this.parent = parent;
+        this.display = display;
+    }
+
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @Nullable
+    public PreparedAdvancementWrapper getParent() {
+        return parent;
+    }
+
+    @NotNull
+    public AdvancementDisplayWrapper getDisplay() {
+        return display;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return this.advancementHolder.value().requirements().size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementHolder toNMS() {
+        return advancementHolder;
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/PreparedAdvancementDisplayWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/PreparedAdvancementDisplayWrapper_v26_1_R2.java
@@ -1,0 +1,111 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.util.JsonString;
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementFrameTypeWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementDisplayWrapper;
+import com.google.gson.JsonParseException;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStackTemplate;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class PreparedAdvancementDisplayWrapper_v26_1_R2 extends PreparedAdvancementDisplayWrapper {
+
+    private final ItemStackTemplate icon;
+    private final Component title, description;
+    private final AdvancementFrameTypeWrapper frameType;
+    private final float x, y;
+    private final boolean showToast, announceChat, hidden;
+
+    public PreparedAdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStack icon, @NotNull BaseComponent title, @NotNull BaseComponent description, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden) {
+        this.icon = ItemStackTemplate.fromNonEmptyStack(CraftItemStack.asNMSCopy(icon));
+        this.title = Util.fromComponent(title);
+        this.description = Util.fromComponent(description);
+        this.frameType = frameType;
+        this.x = x;
+        this.y = y;
+        this.showToast = showToast;
+        this.announceChat = announceChat;
+        this.hidden = hidden;
+    }
+
+    public PreparedAdvancementDisplayWrapper_v26_1_R2(@NotNull ItemStack icon, @NotNull JsonString jsonTitle, @NotNull JsonString jsonDescription, @NotNull AdvancementFrameTypeWrapper frameType, float x, float y, boolean showToast, boolean announceChat, boolean hidden) throws JsonParseException {
+        this.icon = ItemStackTemplate.fromNonEmptyStack(CraftItemStack.asNMSCopy(icon));
+        this.title = Util.fromJSON(jsonTitle.jsonString());
+        this.description = Util.fromJSON(jsonDescription.jsonString());
+        this.frameType = frameType;
+        this.x = x;
+        this.y = y;
+        this.showToast = showToast;
+        this.announceChat = announceChat;
+        this.hidden = hidden;
+    }
+
+    @Override
+    @NotNull
+    public ItemStack getIcon() {
+        return CraftItemStack.asBukkitCopy(icon.create());
+    }
+
+    @Override
+    @NotNull
+    public BaseComponent getTitle() {
+        return Util.toComponent(title);
+    }
+
+    @Override
+    @NotNull
+    public BaseComponent getDescription() {
+        return Util.toComponent(description);
+    }
+
+    @Override
+    @NotNull
+    public AdvancementFrameTypeWrapper getAdvancementFrameType() {
+        return frameType;
+    }
+
+    @Override
+    public float getX() {
+        return x;
+    }
+
+    @Override
+    public float getY() {
+        return y;
+    }
+
+    @Override
+    public boolean doesShowToast() {
+        return showToast;
+    }
+
+    @Override
+    public boolean doesAnnounceToChat() {
+        return announceChat;
+    }
+
+    @Override
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    @Override
+    @NotNull
+    public AdvancementDisplayWrapper toBaseAdvancementDisplay() {
+        return new AdvancementDisplayWrapper_v26_1_R2(icon, title, description, frameType, x, y, showToast, announceChat, hidden, null);
+    }
+
+    @Override
+    @NotNull
+    public AdvancementDisplayWrapper toRootAdvancementDisplay(@NotNull String backgroundTexture) {
+        Objects.requireNonNull(backgroundTexture, "The background texture is null.");
+        return new AdvancementDisplayWrapper_v26_1_R2(icon, title, description, frameType, x, y, showToast, announceChat, hidden, backgroundTexture);
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/PreparedAdvancementWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/advancement/PreparedAdvancementWrapper_v26_1_R2.java
@@ -1,0 +1,74 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.advancement;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementDisplayWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.PreparedAdvancementWrapper;
+import com.google.common.base.Preconditions;
+import net.minecraft.advancements.AdvancementRequirements;
+import net.minecraft.advancements.Criterion;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.Map;
+
+public class PreparedAdvancementWrapper_v26_1_R2 extends PreparedAdvancementWrapper {
+
+    private final MinecraftKeyWrapper key;
+    private final PreparedAdvancementWrapper parent;
+    private final Map<String, Criterion<?>> advCriteria;
+    private final AdvancementRequirements advRequirements;
+
+    public PreparedAdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @Nullable PreparedAdvancementWrapper parent, @Range(from = 1, to = Integer.MAX_VALUE) int maxProgression) {
+        this.key = key;
+        this.parent = parent;
+        this.advCriteria = Util.getAdvancementCriteria(maxProgression);
+        this.advRequirements = Util.getAdvancementRequirements(advCriteria);
+    }
+
+    protected PreparedAdvancementWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key, @Nullable PreparedAdvancementWrapper parent, @NotNull Map<String, Criterion<?>> advCriteria, @NotNull AdvancementRequirements advRequirements) {
+        this.key = key;
+        this.parent = parent;
+        this.advCriteria = advCriteria;
+        this.advRequirements = advRequirements;
+    }
+
+    @Override
+    @NotNull
+    public MinecraftKeyWrapper getKey() {
+        return key;
+    }
+
+    @Override
+    @Nullable
+    public PreparedAdvancementWrapper getParent() {
+        return parent;
+    }
+
+    @Override
+    @Range(from = 1, to = Integer.MAX_VALUE)
+    public int getMaxProgression() {
+        return advRequirements.size();
+    }
+
+    @Override
+    @NotNull
+    public AdvancementWrapper toAdvancementWrapper(@NotNull AdvancementDisplayWrapper display) {
+        Preconditions.checkNotNull(display, "AdvancementDisplayWrapper is null.");
+        if (parent == null) {
+            return new AdvancementWrapper_v26_1_R2(key, display, advCriteria, advRequirements);
+        } else {
+            return new AdvancementWrapper_v26_1_R2(key, parent, display, advCriteria, advRequirements);
+        }
+    }
+
+    @Override
+    @NotNull
+    @Contract("_ -> new")
+    public PreparedAdvancementWrapper withParent(@Nullable PreparedAdvancementWrapper parent) {
+        return new PreparedAdvancementWrapper_v26_1_R2(key, parent, advCriteria, advRequirements);
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutAdvancementsWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutAdvancementsWrapper_v26_1_R2.java
@@ -1,0 +1,49 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.util.ListSet;
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.advancement.AdvancementWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutAdvancementsWrapper;
+import com.google.common.collect.Maps;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class PacketPlayOutAdvancementsWrapper_v26_1_R2 extends PacketPlayOutAdvancementsWrapper {
+
+    private final ClientboundUpdateAdvancementsPacket packet;
+
+    public PacketPlayOutAdvancementsWrapper_v26_1_R2() {
+        this.packet = new ClientboundUpdateAdvancementsPacket(true, Collections.emptyList(), Collections.emptySet(), Collections.emptyMap(), true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v26_1_R2(@NotNull Map<AdvancementWrapper, Integer> toSend) {
+        Map<Identifier, AdvancementProgress> map = Maps.newHashMapWithExpectedSize(toSend.size());
+        for (Entry<AdvancementWrapper, Integer> e : toSend.entrySet()) {
+            AdvancementWrapper adv = e.getKey();
+            map.put((Identifier) adv.getKey().toNMS(), Util.getAdvancementProgress((AdvancementHolder) adv.toNMS(), e.getValue()));
+        }
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, (Collection<AdvancementHolder>) ListSet.fromWrapperSet(toSend.keySet()), Collections.emptySet(), map, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public PacketPlayOutAdvancementsWrapper_v26_1_R2(@NotNull Set<MinecraftKeyWrapper> toRemove) {
+        this.packet = new ClientboundUpdateAdvancementsPacket(false, Collections.emptyList(), (Set<Identifier>) ListSet.fromWrapperSet(toRemove), Collections.emptyMap(), true);
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2.java
+++ b/NMS/26_1_R2/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/v26_1_R2/packets/PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2.java
@@ -1,0 +1,27 @@
+package com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.packets;
+
+import com.fren_gor.ultimateAdvancementAPI.nms.v26_1_R2.Util;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.MinecraftKeyWrapper;
+import com.fren_gor.ultimateAdvancementAPI.nms.wrappers.packets.PacketPlayOutSelectAdvancementTabWrapper;
+import net.minecraft.network.protocol.game.ClientboundSelectAdvancementsTabPacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2 extends PacketPlayOutSelectAdvancementTabWrapper {
+
+    private final ClientboundSelectAdvancementsTabPacket packet;
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2() {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) null);
+    }
+
+    public PacketPlayOutSelectAdvancementTabWrapper_v26_1_R2(@NotNull MinecraftKeyWrapper key) {
+        packet = new ClientboundSelectAdvancementsTabPacket((Identifier) key.toNMS());
+    }
+
+    @Override
+    public void sendTo(@NotNull Player player) {
+        Util.sendTo(player, packet);
+    }
+}

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -20,9 +20,17 @@
         <!-- Put before every other dependency in order to have it loaded before Spigot dependency-->
         <!-- See https://github.com/MockBukkit/MockBukkit/issues/462 and https://github.com/MockBukkit/MockBukkit/issues/462#issuecomment-1156574495 -->
         <dependency>
-            <groupId>com.github.seeseemelk</groupId>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
             <artifactId>${mockBukkitArtifact}</artifactId>
             <version>${mockBukkitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Paper API for tests (MockBukkit is based on Paper, so we can use it in tests) -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${mockBukkitPaperAPIVersion}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/NMS/Common/pom.xml
+++ b/NMS/Common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-common</artifactId>

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ReflectionUtil.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/nms/util/ReflectionUtil.java
@@ -14,10 +14,33 @@ import java.util.Optional;
 public final class ReflectionUtil {
 
     /**
-     * The Minecraft version.
-     * <p>For example {@code 1.17.1}.
+     * The complete Minecraft version.
+     * <p>For example {@code 1.17.1} or {@code 26.1.2}.
      */
-    public static final String MINECRAFT_VERSION = Bukkit.getBukkitVersion().split("-")[0];
+    public static final String MINECRAFT_VERSION = getMinecraftVersion();
+
+    private static String getMinecraftVersion() {
+        try {
+            // Paper-only method
+            return (String) Bukkit.class.getDeclaredMethod("getMinecraftVersion").invoke(null);
+        } catch (ReflectiveOperationException e) {
+            return Bukkit.getBukkitVersion().split("-")[0];
+        }
+    }
+
+    /**
+     * The Minecraft major version.
+     * <p>For example, for {@code 1.19.2} it is {@code 1}.
+     * For {@code 26.1.2} it is {@code 26}.
+     */
+    public static final int MAJOR_VERSION;
+
+    /**
+     * The Minecraft version.
+     * <p>For example, for {@code 1.17.1} it is {@code 17}.
+     * For {@code 26.1.2} it is {@code 1}.
+     */
+    public static final int VERSION;
 
     /**
      * The Minecraft minor version.
@@ -27,6 +50,10 @@ public final class ReflectionUtil {
 
     static {
         var splitted = MINECRAFT_VERSION.split("\\.");
+
+        MAJOR_VERSION = Integer.parseInt(splitted[0]);
+        VERSION = Integer.parseInt(splitted[1]);
+
         if (splitted.length > 2) {
             MINOR_VERSION = Integer.parseInt(splitted[2]);
         } else {
@@ -35,14 +62,7 @@ public final class ReflectionUtil {
     }
 
     private static final String CRAFTBUKKIT_PACKAGE = Bukkit.getServer().getClass().getPackage().getName();
-
-    /**
-     * The NMS version.
-     * <p>For example, for {@code v1_17_R1} it is {@code 17}.
-     */
-    public static final int VERSION = Integer.parseInt(MINECRAFT_VERSION.split("\\.")[1]);
-
-    private static final boolean IS_1_17 = VERSION >= 17;
+    private static final boolean IS_1_17 = MAJOR_VERSION >= 26 || (MAJOR_VERSION == 1 && VERSION >= 17);
 
     /**
      * Returns whether the provided class exists.

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -16,7 +16,7 @@ import java.util.Optional;
  */
 public final class Versions {
 
-    private static final String API_VERSION = "3.0.0-beta-1";
+    private static final String API_VERSION = "3.0.0-beta-2";
 
     private static final List<String> SUPPORTED_NMS_VERSIONS = List.of(
             "v1_15_R1",

--- a/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
+++ b/NMS/Common/src/main/java/com/fren_gor/ultimateAdvancementAPI/util/Versions.java
@@ -39,7 +39,8 @@ public final class Versions {
             "v1_21_R4",
             "v1_21_R5",
             "v1_21_R6",
-            "v1_21_R7"
+            "v1_21_R7",
+            "v26_1_R2"
     );
 
     private static final Map<String, List<String>> NMS_TO_VERSIONS = Map.ofEntries(
@@ -63,7 +64,8 @@ public final class Versions {
             Map.entry("v1_21_R4", List.of("1.21.5")),
             Map.entry("v1_21_R5", List.of("1.21.6", "1.21.7", "1.21.8")),
             Map.entry("v1_21_R6", List.of("1.21.9", "1.21.10")),
-            Map.entry("v1_21_R7", List.of("1.21.11"))
+            Map.entry("v1_21_R7", List.of("1.21.11")),
+            Map.entry("v26_1_R2", List.of("26.1", "26.1.1", "26.1.2"))
     );
 
     private static final Map<String, String> NMS_TO_FANCY = Map.ofEntries(
@@ -87,7 +89,8 @@ public final class Versions {
             Map.entry("v1_21_R4", "1.21.5"),
             Map.entry("v1_21_R5", "1.21.6-1.21.8"),
             Map.entry("v1_21_R6", "1.21.9-1.21.10"),
-            Map.entry("v1_21_R7", "1.21.11")
+            Map.entry("v1_21_R7", "1.21.11"),
+            Map.entry("v26_1_R2", "26.1-26.1.2")
     );
 
     private static final List<String> SUPPORTED_VERSIONS = SUPPORTED_NMS_VERSIONS.stream()

--- a/NMS/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/util/VersionsTest.java
+++ b/NMS/Common/src/test/java/com/fren_gor/ultimateAdvancementAPI/util/VersionsTest.java
@@ -1,9 +1,9 @@
 package com.fren_gor.ultimateAdvancementAPI.util;
 
-import be.seeseemelk.mockbukkit.MockBukkitExtension;
 import org.bukkit.Bukkit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 import static com.fren_gor.ultimateAdvancementAPI.util.Versions.getApiVersion;
 import static com.fren_gor.ultimateAdvancementAPI.util.Versions.getNMSVersionsList;

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-distribution</artifactId>

--- a/NMS/Distribution/pom.xml
+++ b/NMS/Distribution/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -51,112 +51,112 @@
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_18_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_18_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_19_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_19_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_19_R3</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R3</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_20_R4</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R1</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R2</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R3</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R4</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R5</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R6</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-nms-1_21_R7</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
         </dependency>
 
         <dependency>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-distribution-mojang-mapped</artifactId>

--- a/NMS/DistributionMojangMapped/pom.xml
+++ b/NMS/DistributionMojangMapped/pom.xml
@@ -159,7 +159,11 @@
             <classifier>mojang-mapped</classifier>
         </dependency>
 
-        <!-- When adding a version remember to add the CraftBukkit relocation below -->
+        <dependency>
+            <groupId>com.frengor</groupId>
+            <artifactId>ultimateadvancementapi-nms-26_1_R2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NMS/MockedImplementation/pom.xml
+++ b/NMS/MockedImplementation/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-nms-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-mocked</artifactId>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -45,6 +45,7 @@
         <module>1_21_R5</module>
         <module>1_21_R6</module>
         <module>1_21_R7</module>
+        <module>26_1_R2</module>
         <module>Distribution</module>
         <module>DistributionMojangMapped</module>
         <module>MockedImplementation</module>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-nms-parent</artifactId>

--- a/NMS/pom.xml
+++ b/NMS/pom.xml
@@ -62,7 +62,7 @@
                         <execution>
                             <id>generate-mojang-mapped-jar</id>
                             <configuration>
-                                <classifier>mojang-mapped</classifier>
+                                <classifier>mojang-mapped-legacy</classifier>
                             </configuration>
                         </execution>
                     </executions>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped.jar</mojangMappedJarFile>
+        <mojangMappedJarFile>${project.build.directory}/${project.build.finalName}-Mojang-Mapped-Legacy.jar</mojangMappedJarFile>
 
         <!-- Skip deploy -->
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -79,7 +79,7 @@
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-shadeable</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
@@ -93,7 +93,7 @@
             <groupId>com.frengor</groupId>
             <artifactId>ultimateadvancementapi-commands</artifactId>
             <version>${project.version}</version>
-            <classifier>mojang-mapped</classifier>
+            <classifier>mojang-mapped-legacy</classifier>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
@@ -165,8 +165,8 @@
                         <configuration>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>com.frengor:ultimateadvancementapi-shadeable:mojang-mapped</exclude>
-                                    <exclude>com.frengor:ultimateadvancementapi-commands:mojang-mapped</exclude>
+                                    <exclude>com.frengor:ultimateadvancementapi-shadeable:mojang-mapped-legacy</exclude>
+                                    <exclude>com.frengor:ultimateadvancementapi-commands:mojang-mapped-legacy</exclude>
                                 </excludes>
                             </artifactSet>
 
@@ -225,7 +225,7 @@
                                 <artifact>
                                     <file>${mojangMappedJarFile}</file>
                                     <type>jar</type>
-                                    <classifier>mojang-mapped</classifier>
+                                    <classifier>mojang-mapped-legacy</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.frengor</groupId>
         <artifactId>ultimateadvancementapi-parent</artifactId>
-        <version>3.0.0-beta-1</version>
+        <version>3.0.0-beta-2</version>
     </parent>
 
     <artifactId>ultimateadvancementapi-plugin</artifactId>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A powerful API to create custom advancements for your minecraft server.
 <dependency>
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi</artifactId>
-    <version>3.0.0-beta-1</version>
+    <version>3.0.0-beta-2</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -43,17 +43,20 @@
     </modules>
 
     <properties>
-        <!-- Project Properties -->
+        <!-- Dependencies Properties -->
         <libbyVersion>1.3.0</libbyVersion>
         <eventManagerAPIVersion>1.0-SNAPSHOT</eventManagerAPIVersion>
-        <mockBukkitArtifact>MockBukkit-v1.21</mockBukkitArtifact>
-        <mockBukkitVersion>3.133.2</mockBukkitVersion>
+        <mockBukkitArtifact>mockbukkit-v1.21</mockBukkitArtifact>
+        <mockBukkitVersion>4.108.0</mockBukkitVersion>
+        <mockBukkitPaperAPIVersion>1.21.11-R0.1-SNAPSHOT</mockBukkitPaperAPIVersion>
+
         <maven.javadoc.skip>false</maven.javadoc.skip>
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <argLine/> <!-- https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3 -->
     </properties>
 
     <repositories>
@@ -115,7 +118,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.11.0</version>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -123,7 +126,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.0</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -322,6 +325,8 @@
                     <parallel>none</parallel>
                     <trimStackTrace>false</trimStackTrace>
                     <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds> <!-- 5 minutes -->
+                    <!-- https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3 -->
+                    <argLine>@{argLine} -XX:+EnableDynamicAgentLoading --enable-native-access=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.frengor</groupId>
     <artifactId>ultimateadvancementapi-parent</artifactId>
-    <version>3.0.0-beta-1</version>
+    <version>3.0.0-beta-2</version>
     <packaging>pom</packaging>
 
     <name>UltimateAdvancementAPI-Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,7 @@
         <projectEncoding>UTF-8</projectEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <argLine/> <!-- https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3 -->
     </properties>
 


### PR DESCRIPTION
* Updated version to 3.0.0-beta-2
* Updated to Minecraft 26.1.2
* Updated CommandAPI to 11.2.0
* Renamed the `mojang-mapped` classifier to `mojang-mapped-legacy`. Starting from 26.1.2, both Spigot and Paper are mojang mapped, so the mojang-mapped versions are only useful on (mojang mapped) Paper 1.18-1.21.11 servers.
* Minor improvements